### PR TITLE
Add basic impl for HSL, HSLA

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,9 +156,68 @@ impl Color for RGBA {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+/// A struct to represent how much hue, saturation, and luminosity should be added to create a color.
+/// The hue is a degree on the color wheel; 0 (or 360) is red, 120 is green, 240 is blue.
+/// A valid value for `h` must range between `0-360`.
+/// The saturation ranges between `0-100`, where `0` is completely desaturated, and `100` is full saturation.
+/// The luminosity ranges between `0-100`, where `0` is no light (black), and `100` is full light (white).
+///
+/// For more, see the [CSS Color Spec](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#hsl-color).
+pub struct HSL {
+    // TOD0: can i do this with only u8's? is f32 really the best type here??
+    // FIXME: make sure this panics when it exceeds upper bounds.
+    // hue
+    pub h: f32,
+
+    // saturation
+    pub s: u8,
+
+    // luminosity
+    pub l: u8,
+}
+
+impl fmt::Display for HSL {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "hsl({}, {}%, {}%)", self.h, self.s, self.l)
+    }
+}
+
+impl HSL {
+    /// Transforms numerical values into a HSL struct.
+    ///
+    /// # Example
+    /// ```
+    /// use css_colors::HSL;
+    ///
+    /// let salmon = HSL::new(6.0, 93, 71);
+    ///
+    /// assert_eq!(salmon, HSL { h: 6.0, s: 93, l: 71 });
+    /// ```
+    pub fn new(h: f32, s: u8, l: u8) -> HSL {
+        HSL { h, s, l }
+    }
+}
+
+impl Color for HSL {
+    fn to_css(self) -> String {
+        self.to_string()
+    }
+
+    fn to_rgb(self) -> RGB {
+        // FIXME: create impl, add tests for this
+        RGB::new(self.h as u8, self.s, self.l)
+    }
+
+    fn to_rgba(self) -> RGBA {
+        // FIXME: create impl, add tests for this
+        RGBA::new(self.h as u8, self.s, self.l, 255)
+    }
+}
+
 #[cfg(test)]
 mod css_color_tests {
-    use {Color, RGB, RGBA};
+    use {Color, RGB, RGBA, HSL};
 
     #[test]
     fn can_create_color_structs() {
@@ -170,6 +229,14 @@ mod css_color_tests {
                 g: 10,
                 b: 15,
                 a: 255
+            }
+        );
+        assert_eq!(
+            HSL::new(6.0, 93, 71),
+            HSL {
+                h: 6.0,
+                s: 93,
+                l: 71
             }
         );
     }
@@ -205,9 +272,15 @@ mod css_color_tests {
             b: 15,
             a: 255,
         };
+        let hsl_color = HSL {
+            h: 6.0,
+            s: 93,
+            l: 71,
+        };
 
         assert_eq!(rgb_color, rgb_color.clone());
         assert_eq!(rgba_color, rgba_color.clone());
+        assert_eq!(hsl_color, hsl_color.clone());
     }
 
     #[test]
@@ -226,9 +299,16 @@ mod css_color_tests {
             a: 255,
         };
         let copied_rgba_color = rgba_color;
+        let hsl_color = HSL {
+            h: 6.0,
+            s: 93,
+            l: 71,
+        };
+        let copied_hsl_color = hsl_color;
 
         assert_eq!(rgb_color, copied_rgb_color);
         assert_eq!(rgba_color, copied_rgba_color);
+        assert_eq!(hsl_color, copied_hsl_color);
     }
 
     #[test]
@@ -243,9 +323,18 @@ mod css_color_tests {
                 a: 255
             }
         );
+        let hsl_value = format!(
+            "{:?}",
+            HSL {
+                h: 6.0,
+                s: 93,
+                l: 71,
+            }
+        );
 
         assert_eq!(rgb_value, "RGB { r: 5, g: 10, b: 15 }");
         assert_eq!(rgba_value, "RGBA { r: 5, g: 10, b: 15, a: 255 }");
+        assert_eq!(hsl_value, "HSL { h: 6.0, s: 93, l: 71 }");
     }
 
     #[test]
@@ -261,9 +350,15 @@ mod css_color_tests {
             b: 255,
             a: 255,
         };
+        let hsl = HSL {
+            h: 6.0,
+            s: 93,
+            l: 71,
+        };
 
         assert_eq!(rgb.to_css(), "rgb(5, 10, 255)");
         assert_eq!(rgba.to_css(), "rgba(5, 10, 255, 1.00)");
+        assert_eq!(hsl.to_css(), "hsl(6, 93%, 71%)");
     }
 
     #[test]
@@ -285,9 +380,18 @@ mod css_color_tests {
                 a: 255,
             }
         );
+        let printed_hsl = format!(
+            "{}",
+            HSL {
+                h: 6.0,
+                s: 93,
+                l: 71,
+            }
+        );
 
         assert_eq!(printed_rgb, "rgb(5, 10, 255)");
         assert_eq!(printed_rgba, "rgba(5, 10, 255, 1.00)");
+        assert_eq!(printed_hsl, "hsl(6, 93%, 71%)");
     }
 
     #[test]
@@ -303,9 +407,15 @@ mod css_color_tests {
             b: 255,
             a: 190,
         };
+        let hsl = HSL {
+            h: 6.0,
+            s: 93,
+            l: 71,
+        };
 
         assert_eq!("rgb(5, 10, 255)".to_owned(), format!("{}", rgb));
         assert_eq!("rgba(5, 10, 255, 0.75)".to_owned(), format!("{}", rgba));
+        assert_eq!("hsl(6, 93%, 71%)".to_owned(), format!("{}", hsl));
     }
 
     #[test]
@@ -321,8 +431,14 @@ mod css_color_tests {
             b: 255,
             a: 128,
         };
+        let hsl = HSL {
+            h: 6.0,
+            s: 93,
+            l: 71,
+        };
 
         assert_eq!(String::from("rgb(5, 10, 255)"), rgb.to_string());
         assert_eq!(String::from("rgba(5, 10, 255, 0.50)"), rgba.to_string());
+        assert_eq!(String::from("hsl(6, 93%, 71%)"), hsl.to_string());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,12 +206,12 @@ impl Color for HSL {
 
     fn to_rgb(self) -> RGB {
         // FIXME: create impl, add tests for this
-        RGB::new(self.h as u8, self.s, self.l)
+        RGB::new(0, 0, 0)
     }
 
     fn to_rgba(self) -> RGBA {
         // FIXME: create impl, add tests for this
-        RGBA::new(self.h as u8, self.s, self.l, 255)
+        RGBA::new(0, 0, 0, 0)
     }
 }
 
@@ -269,12 +269,12 @@ impl Color for HSLA {
 
     fn to_rgb(self) -> RGB {
         // FIXME: create impl, add tests for this
-        RGB::new(self.h as u8, self.s, self.l)
+        RGB::new(0, 0, 0)
     }
 
     fn to_rgba(self) -> RGBA {
         // FIXME: create impl, add tests for this
-        RGBA::new(self.h as u8, self.s, self.l, self.a)
+        RGBA::new(0, 0, 0, 0)
     }
 }
 
@@ -322,6 +322,17 @@ mod css_color_tests {
             b: 15,
             a: 255,
         };
+        let hsl_color = HSL {
+            h: 6.0,
+            s: 93,
+            l: 71,
+        };
+        let hsla_color = HSLA {
+            h: 6.0,
+            s: 93,
+            l: 71,
+            a: 255,
+        };
 
         assert_eq!(
             rgb_color.to_rgba(),
@@ -333,6 +344,12 @@ mod css_color_tests {
             }
         );
         assert_eq!(rgba_color.to_rgb(), RGB { r: 5, g: 10, b: 15 });
+
+        // FIXME: update these tests once HSL <-> RBG impl exists
+        assert_eq!(hsl_color.to_rgb(), RGB { r: 0, g: 0, b: 0 });
+        assert_eq!(hsl_color.to_rgba(), RGBA { r: 0, g: 0, b: 0, a: 0 });
+        assert_eq!(hsla_color.to_rgb(), RGB { r: 0, g: 0, b: 0 });
+        assert_eq!(hsla_color.to_rgba(), RGBA { r: 0, g: 0, b: 0, a: 0 });
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ impl HSL {
     ///
     /// let salmon = HSL::new(Angle::new(6), 93, 71);
     ///
-    /// assert_eq!(salmon, HSL { h: Angle { degrees: 6 }, s: 93, l: 71 });
+    /// assert_eq!(salmon, HSL { h: Angle::new(6), s: 93, l: 71 });
     /// ```
     pub fn new(h: Angle, s: u8, l: u8) -> HSL {
         HSL { h, s, l }
@@ -251,7 +251,7 @@ impl HSLA {
     /// use {css_colors::HSLA, css_colors::Angle};
     /// let light_salmon = HSLA::new(Angle::new(6), 93, 71, 128);
     ///
-    /// assert_eq!(light_salmon, HSLA { h: Angle { degrees: 6 }, s: 93, l: 71, a: 128 });
+    /// assert_eq!(light_salmon, HSLA { h: Angle::new(6), s: 93, l: 71, a: 128 });
     /// ```
     pub fn new(h: Angle, s: u8, l: u8, a: u8) -> HSLA {
         HSLA { h, s, l, a }
@@ -278,7 +278,7 @@ impl Color for HSLA {
 /// A struct that represents the number of degrees in a circle.
 /// Legal values range from `0-359`. Anything else is unsused.
 pub struct Angle {
-    pub degrees: u16,
+    degrees: u16,
 }
 
 impl Angle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,9 +215,72 @@ impl Color for HSL {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+/// A struct to represent how much hue, saturation, and luminosity should be added to create a color.
+/// Also handles alpha specifications.
+///
+/// A valid value for `h` must range between `0-360`.
+/// The saturation ranges between `0-100`, where `0` is completely desaturated, and `100` is full saturation.
+/// The luminosity ranges between `0-100`, where `0` is no light (black), and `100` is full light (white).
+///
+/// For more, see the [CSS Color Spec](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#hsla-color).
+pub struct HSLA {
+    // TOD0: can i do this with only u8's? is f32 really the best type here??
+    // FIXME: make sure this panics when it exceeds upper bounds.
+    // hue
+    pub h: f32,
+
+    // saturation
+    pub s: u8,
+
+    // luminosity
+    pub l: u8,
+
+    // alpha
+    pub a: u8,
+}
+
+impl fmt::Display for HSLA {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "hsla({}, {}%, {}%, {:.02})", self.h, self.s, self.l, self.a as f32 / 255.0)
+    }
+}
+
+impl HSLA {
+    /// Transforms numerical values into a HSL struct.
+    ///
+    /// # Example
+    /// ```
+    /// use css_colors::HSLA;
+    ///
+    /// let light_salmon = HSLA::new(6.0, 93, 71, 128);
+    ///
+    /// assert_eq!(light_salmon, HSLA { h: 6.0, s: 93, l: 71, a: 128 });
+    /// ```
+    pub fn new(h: f32, s: u8, l: u8, a: u8) -> HSLA {
+        HSLA { h, s, l, a }
+    }
+}
+
+impl Color for HSLA {
+    fn to_css(self) -> String {
+        self.to_string()
+    }
+
+    fn to_rgb(self) -> RGB {
+        // FIXME: create impl, add tests for this
+        RGB::new(self.h as u8, self.s, self.l)
+    }
+
+    fn to_rgba(self) -> RGBA {
+        // FIXME: create impl, add tests for this
+        RGBA::new(self.h as u8, self.s, self.l, self.a)
+    }
+}
+
 #[cfg(test)]
 mod css_color_tests {
-    use {Color, RGB, RGBA, HSL};
+    use {Color, RGB, RGBA, HSL, HSLA};
 
     #[test]
     fn can_create_color_structs() {
@@ -237,6 +300,15 @@ mod css_color_tests {
                 h: 6.0,
                 s: 93,
                 l: 71
+            }
+        );
+        assert_eq!(
+            HSLA::new(6.0, 93, 71, 255),
+            HSLA {
+                h: 6.0,
+                s: 93,
+                l: 71,
+                a: 255
             }
         );
     }
@@ -277,10 +349,17 @@ mod css_color_tests {
             s: 93,
             l: 71,
         };
+        let hsla_color = HSLA {
+            h: 6.0,
+            s: 93,
+            l: 71,
+            a: 255,
+        };
 
         assert_eq!(rgb_color, rgb_color.clone());
         assert_eq!(rgba_color, rgba_color.clone());
         assert_eq!(hsl_color, hsl_color.clone());
+        assert_eq!(hsla_color, hsla_color.clone());
     }
 
     #[test]
@@ -305,10 +384,18 @@ mod css_color_tests {
             l: 71,
         };
         let copied_hsl_color = hsl_color;
+        let hsla_color = HSLA {
+            h: 6.0,
+            s: 93,
+            l: 71,
+            a: 255,
+        };
+        let copied_hsla_color = hsla_color;
 
         assert_eq!(rgb_color, copied_rgb_color);
         assert_eq!(rgba_color, copied_rgba_color);
         assert_eq!(hsl_color, copied_hsl_color);
+        assert_eq!(hsla_color, copied_hsla_color);
     }
 
     #[test]
@@ -331,10 +418,20 @@ mod css_color_tests {
                 l: 71,
             }
         );
+        let hsla_value = format!(
+            "{:?}",
+            HSLA {
+                h: 6.0,
+                s: 93,
+                l: 71,
+                a: 255
+            }
+        );
 
         assert_eq!(rgb_value, "RGB { r: 5, g: 10, b: 15 }");
         assert_eq!(rgba_value, "RGBA { r: 5, g: 10, b: 15, a: 255 }");
         assert_eq!(hsl_value, "HSL { h: 6.0, s: 93, l: 71 }");
+        assert_eq!(hsla_value, "HSLA { h: 6.0, s: 93, l: 71, a: 255 }");
     }
 
     #[test]
@@ -355,10 +452,17 @@ mod css_color_tests {
             s: 93,
             l: 71,
         };
+        let hsla = HSLA {
+            h: 6.0,
+            s: 93,
+            l: 71,
+            a: 255,
+        };
 
         assert_eq!(rgb.to_css(), "rgb(5, 10, 255)");
         assert_eq!(rgba.to_css(), "rgba(5, 10, 255, 1.00)");
         assert_eq!(hsl.to_css(), "hsl(6, 93%, 71%)");
+        assert_eq!(hsla.to_css(), "hsla(6, 93%, 71%, 1.00)");
     }
 
     #[test]
@@ -388,10 +492,20 @@ mod css_color_tests {
                 l: 71,
             }
         );
+        let printed_hsla = format!(
+            "{}",
+            HSLA {
+                h: 6.0,
+                s: 93,
+                l: 71,
+                a: 255,
+            }
+        );
 
         assert_eq!(printed_rgb, "rgb(5, 10, 255)");
         assert_eq!(printed_rgba, "rgba(5, 10, 255, 1.00)");
         assert_eq!(printed_hsl, "hsl(6, 93%, 71%)");
+        assert_eq!(printed_hsla, "hsla(6, 93%, 71%, 1.00)");
     }
 
     #[test]
@@ -412,10 +526,17 @@ mod css_color_tests {
             s: 93,
             l: 71,
         };
+        let hsla = HSLA {
+            h: 6.0,
+            s: 93,
+            l: 71,
+            a: 255
+        };
 
         assert_eq!("rgb(5, 10, 255)".to_owned(), format!("{}", rgb));
         assert_eq!("rgba(5, 10, 255, 0.75)".to_owned(), format!("{}", rgba));
         assert_eq!("hsl(6, 93%, 71%)".to_owned(), format!("{}", hsl));
+        assert_eq!("hsla(6, 93%, 71%, 1.00)".to_owned(), format!("{}", hsla));
     }
 
     #[test]
@@ -436,9 +557,16 @@ mod css_color_tests {
             s: 93,
             l: 71,
         };
+        let hsla = HSLA {
+            h: 6.0,
+            s: 93,
+            l: 71,
+            a: 128
+        };
 
         assert_eq!(String::from("rgb(5, 10, 255)"), rgb.to_string());
         assert_eq!(String::from("rgba(5, 10, 255, 0.50)"), rgba.to_string());
         assert_eq!(String::from("hsl(6, 93%, 71%)"), hsl.to_string());
+        assert_eq!(String::from("hsla(6, 93%, 71%, 0.50)"), hsla.to_string());
     }
 }


### PR DESCRIPTION
- [x] Adds [support](https://github.com/vaidehijoshi/css-colors/projects/2#card-12935258) for HSL + HSLA color representation, as well as documentation and [basic tests](https://github.com/vaidehijoshi/css-colors/projects/2#card-12935304).
- [x] Also adds placeholder implementation for converting between HSL/HSLA <-> RGB/RGBA, which will eventually need to be updated once that impl exists. 
