### PR TITLE
Hsl to rgb impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,18 +420,23 @@ impl Color for HSL {
         let mut temporary_g = hue;
         let mut temporary_b = hue - 0.333;
 
-        // TODO: handle what happens if these temporary rgb's are bigger than 1 or less than 0.
-        // can i just use 'as_percentage' here??
+        // TODO: Can I do this in a nicer way?
         if temporary_r > 1.0 {
             temporary_r -= 1.0;
+        } else if temporary_r < 0.0 {
+            temporary_r += 1.0;
         }
 
         if temporary_g > 1.0 {
             temporary_g -= 1.0;
+        } else if temporary_g < 0.0 {
+            temporary_g += 1.0;
         }
 
         if temporary_b > 1.0 {
             temporary_b -= 1.0;
+        } else if temporary_b < 0.0 {
+            temporary_b += 1.0;
         }
 
         let red = HSL::to_rgb_value(temporary_r, temp_1, temp_2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,38 +600,36 @@ mod css_color_tests {
         let rgba_color = RGBA::new(23, 98, 119, 255);
         let hsl_color = HSL::new(193, 67, 28);
         let hsla_color = HSLA::new(193, 67, 28, 255);
+        let another_rgb_color = RGB::new(5, 10, 15);
 
         // HSL to RGB
         assert_eq!(hsl_color.to_rgb(), rgb_color);
         assert_eq!(hsla_color.to_rgb(), rgb_color);
+        assert_eq!(HSL::new(210, 50, 4).to_rgb(), another_rgb_color);
+        assert_eq!(HSLA::new(210, 50, 4, 255).to_rgb(), another_rgb_color);
 
         // RGBA to RGB
         assert_eq!(rgba_color.to_rgb(), rgb_color);
-
-        // TODO: add tests for more conversions.
-        // let another_rgb_color = RGB::new(10, 15, 25);
-        // let another_hsl_color = HSL::new(73, 57, 54);
+        assert_eq!(RGBA::new(5, 10, 15, 255).to_rgb(), another_rgb_color);
     }
 
     #[test]
     fn can_convert_to_rgba_notations() {
-        // TODO: add tests for more conversions.
-        // let rgb_color = RGB::new(5, 10, 15);
-        // let rgba_color = RGBA::new(5, 10, 15, 255);
-        // let hsl_color = HSL::new(6, 93, 71);
-        // let hsla_color = HSLA::new(6, 93, 71, 255);
-
         let rgb_color = RGB::new(23, 98, 119);
         let rgba_color = RGBA::new(23, 98, 119, 255);
         let hsl_color = HSL::new(193, 67, 28);
         let hsla_color = HSLA::new(193, 67, 28, 255);
+        let another_rgba_color = RGBA::new(5, 10, 15, 255);
 
-        // HSL to RGBA (currently unimplemented!)
+        // HSL to RGBA
         assert_eq!(hsl_color.to_rgba(), rgba_color);
         assert_eq!(hsla_color.to_rgba(), rgba_color);
+        assert_eq!(HSL::new(210, 50, 4).to_rgba(), another_rgba_color);
+        assert_eq!(HSLA::new(210, 50, 4, 255).to_rgba(), another_rgba_color);
 
         // RGB to RGBA
         assert_eq!(rgb_color.to_rgba(), rgba_color);
+        assert_eq!(RGB::new(5, 10, 15).to_rgba(), another_rgba_color);
     }
 
     #[test]
@@ -640,13 +638,17 @@ mod css_color_tests {
         let rgba_color = RGBA::new(172, 95, 82, 255);
         let hsl_color = HSL::new(9, 35, 50);
         let hsla_color = HSLA::new(9, 35, 50, 255);
+        let another_hsl_color = HSL::new(210, 50, 4);
 
         // RGB to HSL
         assert_eq!(rgb_color.to_hsl().to_string(), hsl_color.to_string());
         assert_eq!(rgba_color.to_hsl().to_string(), hsl_color.to_string());
+        assert_eq!(RGB::new(5, 10, 15).to_hsl(), another_hsl_color);
+        assert_eq!(RGBA::new(5, 10, 15, 255).to_hsl(), another_hsl_color);
 
         // HSLA to HSL
         assert_eq!(hsla_color.to_hsl().to_string(), hsl_color.to_string());
+        assert_eq!(HSLA::new(210, 50, 4, 255).to_hsl(), another_hsl_color);
     }
 
     #[test]
@@ -655,13 +657,17 @@ mod css_color_tests {
         let rgba_color = RGBA::new(172, 95, 82, 255);
         let hsl_color = HSL::new(9, 35, 50);
         let hsla_color = HSLA::new(9, 35, 50, 255);
+        let another_hsla_color = HSLA::new(210, 50, 4, 255);
 
         // RGB to HSLA
         assert_eq!(rgb_color.to_hsla().to_string(), hsla_color.to_string());
         assert_eq!(rgba_color.to_hsla().to_string(), hsla_color.to_string());
+        assert_eq!(RGB::new(5, 10, 15).to_hsla(), another_hsla_color);
+        assert_eq!(RGBA::new(5, 10, 15, 255).to_hsla(), another_hsla_color);
 
         // HSL to HSLA
         assert_eq!(hsl_color.to_hsla().to_string(), hsla_color.to_string());
+        assert_eq!(HSL::new(210, 50, 4).to_hsla(), another_hsla_color);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,7 @@ impl Color for HSL {
 
     fn to_rgb(self) -> RGB {
         let HSL { h, s, l } = self;
+        let temp_1;
 
         // If there is no saturation, the color is a shade of grey.
         // We can convert the luminosity and set r, g, and b to that value.
@@ -370,9 +371,25 @@ impl Color for HSL {
             let grey = (l as f32 * 255.0 / 100.0).round();
 
             return RGB::new(grey as u8, grey as u8, grey as u8);
+        } else if s < 50 {
+            temp_1 = l as f32 * (1.0 * s as f32);
+        } else {
+            temp_1 = ((l + s) - (l * s)) as f32;
         }
 
-        RGB::new(0, 0, 0)
+        // We need to create some temporary variables. The variables are used to store temporary values which makes the formulas easier to read.
+        //
+        // There are two formulas to choose from in the first step.
+        // If Luminance is smaller then 0.5 (50%) then temporary_1 = Luminance x (1.0+Saturation)
+        // If Luminance is equal or larger then 0.5 (50%) then temporary_1 = Luminance + Saturation – Luminance x Saturation
+        //
+        // Our Luminance is 28%, so we use the first formula.
+        // temporary_1 = 0.28 x (1.0 +0.67) = 0.28 x 1.67 = 0.4676
+
+
+
+
+        RGB::new(temp_1 as u8, temp_1 as u8, temp_1 as u8)
     }
 
     fn to_rgba(self) -> RGBA {
@@ -542,12 +559,12 @@ mod css_color_tests {
 
         // HSL to RGB & RGBA
         assert_eq!(grey_hsl_color.to_rgb(), RGB { r: 64, g: 64, b: 64 });
-        // assert_eq!(hsl_color.to_rgb(), rgb_color);
-        // assert_eq!(hsl_color.to_rgba(), rgba_color);
+        assert_eq!(hsl_color.to_rgb(), rgb_color);
+        assert_eq!(hsl_color.to_rgba(), rgba_color);
 
         // HSLA to RGB & RGBA
-        // assert_eq!(hsla_color.to_rgb(), rgb_color);
-        // assert_eq!(hsla_color.to_rgba(), rgba_color);
+        assert_eq!(hsla_color.to_rgb(), rgb_color);
+        assert_eq!(hsla_color.to_rgba(), rgba_color);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,16 @@ impl Color for HSL {
     }
 
     fn to_rgb(self) -> RGB {
-        unimplemented!("need to impl to_rgb for HSL")
+        let HSL { h, s, l } = self;
+        // If there is no saturation, the color is a shade of grey.
+        // We can If there is no Saturation it means that it’s a shade of grey. So in that case we just need to convert the Luminance and set R,G and B to that level. For example H = 0, S = 0 and L = 40%, we get 0.4 * 255 = 102, so R = 102, G = 102 and B = 102
+
+        if s == 0 {
+            let grey = (l * 255.0) / 100 as u8;
+            return RGB::new(grey, grey, grey);
+        }
+
+        RGB::new(0, 0, 0)
     }
 
     fn to_rgba(self) -> RGBA {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,8 +215,10 @@ impl Color for RGB {
 
         hue *= 60.0;
 
-        // TODO: handle when hue is negative (add 360 to make it positive).
-        assert!(hue >= 0.0, "oops, forgot to handle negative");
+        // If hue is negative, add 360 to make it it positive.
+        if hue <= 0.0 {
+            hue += 360.0;
+        }
 
         HSL::new(
             hue.round() as u16,                 // h
@@ -416,32 +418,13 @@ impl Color for HSL {
         // Convert the hue by dividing the angle by 360.
         let hue = h.degrees() as f32 / 360.0;
 
-        let mut temporary_r = hue + (1.0 / 3.0);
-        let mut temporary_g = hue;
-        let mut temporary_b = hue - (1.0 / 3.0);
+        let temporary_r = hue + (1.0 / 3.0);
+        let temporary_g = hue;
+        let temporary_b = hue - (1.0 / 3.0);
 
-        // TODO: Can I do this in a nicer way?
-        if temporary_r > 1.0 {
-            temporary_r -= 1.0;
-        } else if temporary_r < 0.0 {
-            temporary_r += 1.0;
-        }
-
-        if temporary_g > 1.0 {
-            temporary_g -= 1.0;
-        } else if temporary_g < 0.0 {
-            temporary_g += 1.0;
-        }
-
-        if temporary_b > 1.0 {
-            temporary_b -= 1.0;
-        } else if temporary_b < 0.0 {
-            temporary_b += 1.0;
-        }
-
-        let red = HSL::to_rgb_value(temporary_r, temp_1, temp_2);
-        let green = HSL::to_rgb_value(temporary_g, temp_1, temp_2);
-        let blue = HSL::to_rgb_value(temporary_b, temp_1, temp_2);
+        let red = HSL::to_rgb_value(ensure_in_range(temporary_r), temp_1, temp_2);
+        let green = HSL::to_rgb_value(ensure_in_range(temporary_g), temp_1, temp_2);
+        let blue = HSL::to_rgb_value(ensure_in_range(temporary_b), temp_1, temp_2);
 
         RGB {
             r: Ratio::from_f32(red),
@@ -468,6 +451,17 @@ impl Color for HSL {
             255,
         )
     }
+}
+
+// A function to ensure that a value is always within a range of 0.0 - 1.0.
+fn ensure_in_range(mut value: f32) -> f32 {
+    if value > 1.0 {
+        value -= 1.0;
+    } else if value < 0.0 {
+        value += 1.0;
+    }
+
+    value
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,16 @@ mod css_color_tests {
         conversion_test!(pink, rgb(253, 216, 229), hsl(339, 90, 92));
         conversion_test!(brown, rgb(172, 96, 83), hsl(9, 35, 50));
         conversion_test!(teal, rgb(23, 98, 119), hsl(193, 68, 28));
+        conversion_test!(green, rgb(89, 161, 54), hsl(100, 50, 42));
+        conversion_test!(pale_blue, rgb(148, 189, 209), hsl(200, 40, 70));
+        conversion_test!(mauve, rgb(136, 102, 153), hsl(280, 20, 50));
+        conversion_test!(cherry, rgb(230, 25, 60), hsl(350, 80, 50));
+        conversion_test!(tomato, rgb(255, 99, 71), hsl(9, 100, 64));
+        conversion_test!(light_salmon, rgb(255, 160, 122), hsl(17, 100, 74));
+        conversion_test!(blue_violet, rgb(138, 43, 226), hsl(271, 76, 53));
+        conversion_test!(dark_orange, rgb(255, 140, 0), hsl(33, 100, 50));
+        conversion_test!(deep_pink, rgb(255, 20, 147), hsl(328, 100, 54));
+        conversion_test!(chartreuse, rgb(127, 255, 0), hsl(90, 100, 50));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,12 +363,13 @@ impl Color for HSL {
 
     fn to_rgb(self) -> RGB {
         let HSL { h, s, l } = self;
-        // If there is no saturation, the color is a shade of grey.
-        // We can If there is no Saturation it means that it’s a shade of grey. So in that case we just need to convert the Luminance and set R,G and B to that level. For example H = 0, S = 0 and L = 40%, we get 0.4 * 255 = 102, so R = 102, G = 102 and B = 102
 
+        // If there is no saturation, the color is a shade of grey.
+        // We can convert the luminosity and set r, g, and b to that value.
         if s == 0 {
-            let grey = (l * 255.0) / 100 as u8;
-            return RGB::new(grey, grey, grey);
+            let grey = (l as f32 * 255.0 / 100.0).round();
+
+            return RGB::new(grey as u8, grey as u8, grey as u8);
         }
 
         RGB::new(0, 0, 0)
@@ -539,35 +540,12 @@ mod css_color_tests {
 
         assert_eq!(rgb_color.to_rgba(), rgba_color);
 
-        // FIXME: update these tests once HSL <-> RBG impl exists (currently unimplemented!)
-        // assert_eq!(hsl_color.to_rgba(), rgba_color);
-        // assert_eq!(hsla_color.to_rgba(), rgba_color);
-
-        // RGB <-> RGBA
-        // assert_eq!(
-        //     rgb_color.to_rgba(),
-        //     RGBA {
-        //         r: Ratio::from_u8(5),
-        //         g: Ratio::from_u8(10),
-        //         b: Ratio::from_u8(15),
-        //         a: 255,
-        //     }
-        // );
-        // assert_eq!(
-        //     rgba_color.to_rgb(),
-        //     RGB {
-        //         r: Ratio::from_u8(5),
-        //         g: Ratio::from_u8(10),
-        //         b: Ratio::from_u8(15)
-        //     }
-        // );
-        //
-        // // HSL to RGB & RGBA
-        // assert_eq!(grey_hsl_color.to_rgb(), RGB { r: 64, g: 64, b: 64 });
+        // HSL to RGB & RGBA
+        assert_eq!(grey_hsl_color.to_rgb(), RGB { r: 64, g: 64, b: 64 });
         // assert_eq!(hsl_color.to_rgb(), rgb_color);
         // assert_eq!(hsl_color.to_rgba(), rgba_color);
-        //
-        // // HSLA to RGB & RGBA
+
+        // HSLA to RGB & RGBA
         // assert_eq!(hsla_color.to_rgb(), rgb_color);
         // assert_eq!(hsla_color.to_rgba(), rgba_color);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,29 +356,6 @@ impl HSL {
             l: Ratio::from_percentage(l),
         }
     }
-
-    fn to_rgb_value(value: f32, temp_1: f32, temp_2: f32) -> f32 {
-        let converted: f32;
-
-        // Check whether temporary variable * 6 is larger than one.
-        if value * 6.0 > 1.0 {
-            // If it is larger than 1, check it's product with 2.
-            if value * 2.0 > 1.0 {
-                // If it is large than 1, check it's product with 3.
-                if value * 3.0 > 2.0 {
-                    converted = temp_2;
-                } else {
-                    converted = temp_2 + ((temp_1 - temp_2) * ((2.0 / 3.0) - value) * 6.0);
-                }
-            } else {
-                converted = temp_1;
-            }
-        } else {
-            converted = (temp_2 + (temp_1 - temp_2)) * value * 6.0;
-        }
-
-        converted
-    }
 }
 
 impl Color for HSL {
@@ -422,9 +399,9 @@ impl Color for HSL {
         let temporary_g = hue;
         let temporary_b = hue - (1.0 / 3.0);
 
-        let red = HSL::to_rgb_value(ensure_in_range(temporary_r), temp_1, temp_2);
-        let green = HSL::to_rgb_value(ensure_in_range(temporary_g), temp_1, temp_2);
-        let blue = HSL::to_rgb_value(ensure_in_range(temporary_b), temp_1, temp_2);
+        let red = to_rgb_value(ensure_in_range(temporary_r), temp_1, temp_2);
+        let green = to_rgb_value(ensure_in_range(temporary_g), temp_1, temp_2);
+        let blue = to_rgb_value(ensure_in_range(temporary_b), temp_1, temp_2);
 
         RGB {
             r: Ratio::from_f32(red),
@@ -451,6 +428,30 @@ impl Color for HSL {
             255,
         )
     }
+}
+
+// A function to convert an HSL value (either h, s, or l) into the equivalent, valid RGB value.
+fn to_rgb_value(value: f32, temp_1: f32, temp_2: f32) -> f32 {
+    let converted: f32;
+
+    // Check whether temporary variable * 6 is larger than one.
+    if value * 6.0 > 1.0 {
+        // If it is larger than 1, check it's product with 2.
+        if value * 2.0 > 1.0 {
+            // If it is large than 1, check it's product with 3.
+            if value * 3.0 > 2.0 {
+                converted = temp_2;
+            } else {
+                converted = temp_2 + ((temp_1 - temp_2) * ((2.0 / 3.0) - value) * 6.0);
+            }
+        } else {
+            converted = temp_1;
+        }
+    } else {
+        converted = (temp_2 + (temp_1 - temp_2)) * value * 6.0;
+    }
+
+    converted
 }
 
 // A function to ensure that a value is always within a range of 0.0 - 1.0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,23 +432,18 @@ impl Color for HSL {
 // A function to convert an HSL value (either h, s, or l) into the equivalent, valid RGB value.
 fn to_rgb_value(val: u16, temp_1: f32, temp_2: f32) -> f32 {
     let value = val as f32 / 360.0;
-    // Check whether temporary variable is larger than 1/6th.
-    if value > (1.0 / 6.0) {
-        // If it's larger than 1/6th, then check whether if it's larger than 1/2 or not.
-        if value > (1.0 / 2.0) {
-            if value > (2.0 / 3.0) {
-                // If it's larger than 1/2 and also larger than 2/3rds, set the value to temp_2.
-                temp_2
-            } else {
-                // Otherwise, if it's larger than 1/2 but less than 2/3rds, do some math.
-                temp_2 + ((temp_1 - temp_2) * ((2.0 / 3.0) - value) * 6.0)
-            }
-        } else {
-            // If the value is smaller than 1/6th, set the value to temp_1.
-            temp_1
-        }
+
+    if value > (2.0 / 3.0) {
+        // value > 0.66667
+        temp_2
+    } else if value > (1.0 / 2.0) {
+        // value is between 0.5 and 0.66667
+        temp_2 + ((temp_1 - temp_2) * ((2.0 / 3.0) - value) * 6.0)
+    } else if value > (1.0 / 6.0) {
+        // value is between 0.16667 and 0.5
+        temp_1
     } else {
-        // If it's smaller than 1/6th, do some math.
+        // value <= 0.16667
         temp_2 + ((temp_1 - temp_2) * value * 6.0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,6 +533,34 @@ mod css_color_tests {
         // FIXME: update these tests once HSL <-> RBG impl exists (currently unimplemented!)
         // assert_eq!(hsl_color.to_rgba(), rgba_color);
         // assert_eq!(hsla_color.to_rgba(), rgba_color);
+
+        // RGB <-> RGBA
+        // assert_eq!(
+        //     rgb_color.to_rgba(),
+        //     RGBA {
+        //         r: Ratio::from_u8(5),
+        //         g: Ratio::from_u8(10),
+        //         b: Ratio::from_u8(15),
+        //         a: 255,
+        //     }
+        // );
+        // assert_eq!(
+        //     rgba_color.to_rgb(),
+        //     RGB {
+        //         r: Ratio::from_u8(5),
+        //         g: Ratio::from_u8(10),
+        //         b: Ratio::from_u8(15)
+        //     }
+        // );
+        //
+        // // HSL to RGB & RGBA
+        // assert_eq!(grey_hsl_color.to_rgb(), RGB { r: 64, g: 64, b: 64 });
+        // assert_eq!(hsl_color.to_rgb(), rgb_color);
+        // assert_eq!(hsl_color.to_rgba(), rgba_color);
+        //
+        // // HSLA to RGB & RGBA
+        // assert_eq!(hsla_color.to_rgb(), rgb_color);
+        // assert_eq!(hsla_color.to_rgba(), rgba_color);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,7 @@ impl HSL {
                 if value * 3.0 > 2.0 {
                     converted = temp_2;
                 } else {
-                    converted = temp_2 + ((temp_1 - temp_2) * (0.666 - value) * 6.0);
+                    converted = temp_2 + ((temp_1 - temp_2) * ((2.0 / 3.0) - value) * 6.0);
                 }
             } else {
                 converted = temp_1;
@@ -386,17 +386,17 @@ impl Color for HSL {
 
     fn to_rgb(self) -> RGB {
         let h = self.h;
-        let s = (Ratio::as_f32(self.s) * 100.0).round() / 100.0;
-        let l = (Ratio::as_f32(self.l) * 100.0).round() / 100.0;
+        let s = self.s.as_f32();
+        let l = self.l.as_f32();
 
         // If there is no saturation, the color is a shade of grey.
         // We can convert the luminosity and set r, g, and b to that value.
         if s == 0.0 {
-            return RGB::new(
-                Ratio::from_f32(l).as_u8(),
-                Ratio::from_f32(l).as_u8(),
-                Ratio::from_f32(l).as_u8(),
-            );
+            return RGB {
+                r: self.l,
+                g: self.l,
+                b: self.l,
+            };
         }
 
         // If the color is not a grey, then we need to create a temporary variable to continue with the algorithm.
@@ -416,9 +416,9 @@ impl Color for HSL {
         // Convert the hue by dividing the angle by 360.
         let hue = h.degrees() as f32 / 360.0;
 
-        let mut temporary_r = hue + 0.333;
+        let mut temporary_r = hue + (1.0 / 3.0);
         let mut temporary_g = hue;
-        let mut temporary_b = hue - 0.333;
+        let mut temporary_b = hue - (1.0 / 3.0);
 
         // TODO: Can I do this in a nicer way?
         if temporary_r > 1.0 {
@@ -596,8 +596,8 @@ mod css_color_tests {
 
     #[test]
     fn can_convert_to_rgb_notations() {
-        let rgb_color = RGB::new(24, 98, 119);
-        let rgba_color = RGBA::new(24, 98, 119, 255);
+        let rgb_color = RGB::new(23, 98, 119);
+        let rgba_color = RGBA::new(23, 98, 119, 255);
         let hsl_color = HSL::new(193, 67, 28);
         let hsla_color = HSLA::new(193, 67, 28, 255);
 
@@ -611,7 +611,6 @@ mod css_color_tests {
         // TODO: add tests for more conversions.
         // let another_rgb_color = RGB::new(10, 15, 25);
         // let another_hsl_color = HSL::new(73, 57, 54);
-        // assert_eq!(hsla_color.to_rgb(), rgb_color);
     }
 
     #[test]
@@ -622,8 +621,8 @@ mod css_color_tests {
         // let hsl_color = HSL::new(6, 93, 71);
         // let hsla_color = HSLA::new(6, 93, 71, 255);
 
-        let rgb_color = RGB::new(24, 98, 119);
-        let rgba_color = RGBA::new(24, 98, 119, 255);
+        let rgb_color = RGB::new(23, 98, 119);
+        let rgba_color = RGBA::new(23, 98, 119, 255);
         let hsl_color = HSL::new(193, 67, 28);
         let hsla_color = HSLA::new(193, 67, 28, 255);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,6 +682,45 @@ mod css_color_tests {
     }
 
     #[test]
+    fn can_convert_between_notations() {
+        // Test with brown
+        let rgb_brown = RGB::new(172, 96, 83);
+        let rgba_brown = RGBA::new(172, 96, 83, 255);
+        let hsl_brown = HSL::new(9, 35, 50);
+        let hsla_brown = HSLA::new(9, 35, 50, 255);
+
+        // Test with pink
+        let rgb_pink = RGB::new(253, 216, 229);
+        let rgba_pink = RGBA::new(253, 216, 229, 255);
+        let hsl_pink = HSL::new(340, 89, 92);
+        let hsla_pink = HSLA::new(340, 89, 92, 255);
+
+        // RGB
+        assert_eq!(rgb_brown.to_hsl(), hsl_brown);
+        assert_eq!(rgb_brown.to_hsla(), hsla_brown);
+        assert_eq!(rgb_pink.to_hsl(), hsl_pink); // fails
+        assert_eq!(rgb_pink.to_hsla(), hsla_pink); // fails
+
+        // RGBA
+        assert_eq!(rgba_brown.to_hsl(), hsl_brown);
+        assert_eq!(rgba_brown.to_hsla(), hsla_brown);
+        assert_eq!(rgba_pink.to_hsl(), hsl_pink); // fails
+        assert_eq!(rgba_pink.to_hsla(), hsla_pink); // fails
+
+        // HSL
+        assert_eq!(hsl_brown.to_rgb(), rgb_brown); // fails
+        assert_eq!(hsl_brown.to_rgba(), rgba_brown); // fails
+        assert_eq!(hsl_pink.to_rgb(), rgb_pink); // fails
+        assert_eq!(hsla_pink.to_rgba(), rgba_pink); // fails
+
+        // HSLA
+        assert_eq!(hsla_brown.to_rgb(), rgb_brown); // fails
+        assert_eq!(hsla_brown.to_rgba(), rgba_brown); // fails
+        assert_eq!(hsla_pink.to_rgb(), rgb_pink); // fails
+        assert_eq!(hsla_pink.to_rgba(), rgba_pink); // fails
+    }
+
+    #[test]
     fn can_clone() {
         let rgb_color = RGB::new(5, 10, 15);
         let rgba_color = RGBA::new(5, 10, 15, 255);


### PR DESCRIPTION
- [x] Implements the `HSL` to `RGB` conversion algorithm, as described [here](http://www.niwa.nu/2013/05/math-behind-colorspace-conversions-rgb-hsl). 
- [x] Adds helper functions and tests for these conversions.