### PR TITLE
Add ratio module

### DIFF
--- a/src/angle/mod.rs
+++ b/src/angle/mod.rs
@@ -30,7 +30,9 @@ impl ops::Neg for Angle {
     type Output = Angle;
 
     fn neg(self) -> Angle {
-        Angle { degrees: (360 - self.degrees) % 360 }
+        Angle {
+            degrees: (360 - self.degrees) % 360,
+        }
     }
 }
 
@@ -81,8 +83,8 @@ impl ops::Div for Angle {
 
 #[cfg(test)]
 mod tests {
-    use {Angle};
-    
+    use Angle;
+
     #[test]
     fn can_have_degrees() {
         assert_eq!(Angle::new(30).degrees(), 30);
@@ -125,7 +127,10 @@ mod tests {
         assert_eq!(Angle::new(30) + Angle::new(47), Angle::new(77));
         assert_eq!(Angle::new(47) + Angle::new(30), Angle::new(77));
         assert_eq!(Angle::new(359) + Angle::new(1), Angle::new(0));
-        assert_eq!(Angle::new(359) + Angle::new(359) + Angle::new(359), Angle::new(357));
+        assert_eq!(
+            Angle::new(359) + Angle::new(359) + Angle::new(359),
+            Angle::new(357)
+        );
     }
 
     #[test]
@@ -133,7 +138,10 @@ mod tests {
         assert_eq!(Angle::new(30) - Angle::new(47), Angle::new(343));
         assert_eq!(Angle::new(47) - Angle::new(30), Angle::new(17));
         assert_eq!(Angle::new(0) - Angle::new(1), Angle::new(359));
-        assert_eq!(Angle::new(0) - Angle::new(359) - Angle::new(359) - Angle::new(359), Angle::new(3));
+        assert_eq!(
+            Angle::new(0) - Angle::new(359) - Angle::new(359) - Angle::new(359),
+            Angle::new(3)
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,13 @@ pub trait Color {
     ///
     /// # Examples
     /// ```
-    /// use css_colors::{Color, RGB, RGBA};
+    /// use css_colors::{Color, RGB, RGBA, ratio::Ratio as Ratio};
     ///
-    /// let salmon = RGB { r: 250, g: 128, b: 114 };
-    /// let opaque_salmon = RGBA { r: 250, g: 128, b: 114, a: 128 };
+    /// let salmon = RGB { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114) };
+    /// let opaque_salmon = RGBA { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114), a: 128 };
     ///
-    /// assert_eq!(salmon.to_css(), "rgb(250, 128, 114)");
-    /// assert_eq!(opaque_salmon.to_css(), "rgba(250, 128, 114, 0.50)");
+    /// assert_eq!(salmon.to_css(), "rgb(98%, 50%, 45%)");
+    /// assert_eq!(opaque_salmon.to_css(), "rgba(98%, 50%, 45%, 0.50)");
     /// ```
     fn to_css(self) -> String;
 
@@ -28,11 +28,11 @@ pub trait Color {
     ///
     /// # Examples
     /// ```
-    /// use css_colors::{Color, RGB, RGBA};
+    /// use css_colors::{Color, RGB, RGBA, ratio::Ratio as Ratio};
     ///
-    /// let opaque_tomato = RGBA { r: 255, g: 99, b: 71, a: 128 };
+    /// let opaque_tomato = RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 128 };
     ///
-    /// assert_eq!(opaque_tomato.to_rgb(), RGB { r: 255, g: 99, b: 71 });
+    /// assert_eq!(opaque_tomato.to_rgb(), RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) });
     /// ```
     fn to_rgb(self) -> RGB;
 
@@ -42,11 +42,11 @@ pub trait Color {
     ///
     /// # Examples
     /// ```
-    /// use css_colors::{Color, RGB, RGBA};
+    /// use css_colors::{Color, RGB, RGBA, ratio::Ratio as Ratio};
     ///
-    /// let tomato = RGB { r: 255, g: 99, b: 71 };
+    /// let tomato = RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) };
     ///
-    /// assert_eq!(tomato.to_rgba(), RGBA { r: 255, g: 99, b: 71, a: 255 });
+    /// assert_eq!(tomato.to_rgba(), RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 255 });
     /// ```
     fn to_rgba(self) -> RGBA;
 
@@ -58,8 +58,8 @@ pub trait Color {
     /// ```
     /// use css_colors::{Color, RGB, RGBA, HSL, angle::Angle as Angle, ratio::Ratio as Ratio};
     ///
-    /// let tomato = RGB { r: 255, g: 99, b: 71 };
-    /// let opaque_tomato = RGBA { r: 255, g: 99, b: 71, a: 128 };
+    /// let tomato = RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) };
+    /// let opaque_tomato = RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 128 };
     ///
     /// assert_eq!(tomato.to_hsl(), HSL { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64) });
     /// assert_eq!(opaque_tomato.to_hsl(), HSL { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64) });
@@ -74,8 +74,8 @@ pub trait Color {
     /// ```
     /// use css_colors::{Color, RGB, RGBA, HSLA, angle::Angle as Angle, ratio::Ratio as Ratio};
     ///
-    /// let tomato = RGB { r: 255, g: 99, b: 71 };
-    /// let opaque_tomato = RGBA { r: 255, g: 99, b: 71, a: 128 };
+    /// let tomato = RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) };
+    /// let opaque_tomato = RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 128 };
     ///
     /// assert_eq!(tomato.to_hsla(), HSLA { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64), a: 255 });
     /// assert_eq!(opaque_tomato.to_hsla(), HSLA { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64), a: 128 });
@@ -91,13 +91,13 @@ pub trait Color {
 /// For more, see the [CSS Color Spec](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#rgb-color).
 pub struct RGB {
     // red
-    pub r: u8,
+    pub r: Ratio,
 
     // green
-    pub g: u8,
+    pub g: Ratio,
 
     // blue
-    pub b: u8,
+    pub b: Ratio,
 }
 
 impl fmt::Display for RGB {
@@ -111,13 +111,13 @@ impl RGB {
     ///
     /// # Example
     /// ```
-    /// use css_colors::RGB;
+    /// use {css_colors::RGB, css_colors::ratio::Ratio as Ratio};
     ///
-    /// let salmon = RGB::new(250, 128, 114);
+    /// let salmon = RGB::new(Ratio::from_u8(250), Ratio::from_u8(128), Ratio::from_u8(114));
     ///
-    /// assert_eq!(salmon, RGB { r: 250, g: 128, b: 114 });
+    /// assert_eq!(salmon, RGB { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114) });
     /// ```
-    pub fn new(r: u8, g: u8, b: u8) -> RGB {
+    pub fn new(r: Ratio, g: Ratio, b: Ratio) -> RGB {
         RGB { r, g, b }
     }
 }
@@ -147,7 +147,7 @@ impl Color for RGB {
             return HSL::new(
                 Angle::new(0),             // h
                 Ratio::from_percentage(0), // s
-                Ratio::from_u8(r),         // l
+                r,                         // l
             );
         }
 
@@ -155,10 +155,10 @@ impl Color for RGB {
         // percentage value, find the max and the min of those values, sum them
         // together, and divide by 2.
 
-        // let r = self.r.to_f32() if r is a Ratio
-        let r = self.r as f32 / 255.0;
-        let g = self.g as f32 / 255.0;
-        let b = self.b as f32 / 255.0;
+        // TODO: delete me let r = self.r.to_f32() if r is a Ratio
+        let r = Ratio::as_f32(self.r);
+        let g = Ratio::as_f32(self.g);
+        let b = Ratio::as_f32(self.b);
 
         // let max = vec![r, g, b].iter().max().to_f32()
         let max = if r > g && r > b {
@@ -232,13 +232,13 @@ impl Color for RGB {
 /// For more, see the [CSS Color Spec](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#rgba-color).
 pub struct RGBA {
     // red
-    pub r: u8,
+    pub r: Ratio,
 
     // green
-    pub g: u8,
+    pub g: Ratio,
 
     // blue
-    pub b: u8,
+    pub b: Ratio,
 
     // alpha
     pub a: u8,
@@ -262,13 +262,13 @@ impl RGBA {
     ///
     /// # Example
     /// ```
-    /// use css_colors::RGBA;
+    /// use {css_colors::RGBA, css_colors::ratio::Ratio as Ratio};
     ///
-    /// let light_salmon = RGBA::new(250, 128, 114, 128);
+    /// let light_salmon = RGBA::new(Ratio::from_u8(250), Ratio::from_u8(128), Ratio::from_u8(114), 128);
     ///
-    /// assert_eq!(light_salmon, RGBA { r: 250, g: 128, b: 114, a: 128 });
+    /// assert_eq!(light_salmon, RGBA { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114), a: 128 });
     /// ```
-    pub fn new(r: u8, g: u8, b: u8, a: u8) -> RGBA {
+    pub fn new(r: Ratio, g: Ratio, b: Ratio, a: u8) -> RGBA {
         RGBA { r, g, b, a }
     }
 }
@@ -344,12 +344,12 @@ impl Color for HSL {
 
     fn to_rgb(self) -> RGB {
         // FIXME: create impl, add tests for this
-        RGB::new(0, 0, 0)
+        RGB::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0))
     }
 
     fn to_rgba(self) -> RGBA {
         // FIXME: create impl, add tests for this
-        RGBA::new(0, 0, 0, 0)
+        RGBA::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0), 0)
     }
 
     fn to_hsl(self) -> HSL {
@@ -419,12 +419,12 @@ impl Color for HSLA {
 
     fn to_rgb(self) -> RGB {
         // FIXME: create impl, add tests for this
-        RGB::new(0, 0, 0)
+        RGB::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0))
     }
 
     fn to_rgba(self) -> RGBA {
         // FIXME: create impl, add tests for this
-        RGBA::new(0, 0, 0, 0)
+        RGBA::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0), 0)
     }
 
     fn to_hsl(self) -> HSL {
@@ -442,13 +442,25 @@ mod css_color_tests {
 
     #[test]
     fn can_create_color_structs() {
-        assert_eq!(RGB::new(5, 10, 15), RGB { r: 5, g: 10, b: 15 });
         assert_eq!(
-            RGBA::new(5, 10, 15, 255),
+            RGB::new(Ratio::from_u8(5), Ratio::from_u8(10), Ratio::from_u8(15)),
+            RGB {
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(15)
+            }
+        );
+        assert_eq!(
+            RGBA::new(
+                Ratio::from_u8(5),
+                Ratio::from_u8(10),
+                Ratio::from_u8(15),
+                255
+            ),
             RGBA {
-                r: 5,
-                g: 10,
-                b: 15,
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(15),
                 a: 255
             }
         );
@@ -482,11 +494,15 @@ mod css_color_tests {
 
     #[test]
     fn can_convert_to_rgb_notations() {
-        let rgb_color = RGB { r: 5, g: 10, b: 15 };
+        let rgb_color = RGB {
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(15),
+        };
         let rgba_color = RGBA {
-            r: 5,
-            g: 10,
-            b: 15,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(15),
             a: 255,
         };
         let hsl_color = HSL {
@@ -504,32 +520,53 @@ mod css_color_tests {
         assert_eq!(
             rgb_color.to_rgba(),
             RGBA {
-                r: 5,
-                g: 10,
-                b: 15,
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(15),
                 a: 255,
             }
         );
-        assert_eq!(rgba_color.to_rgb(), RGB { r: 5, g: 10, b: 15 });
+        assert_eq!(
+            rgba_color.to_rgb(),
+            RGB {
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(15)
+            }
+        );
 
         // FIXME: update these tests once HSL <-> RBG impl exists
-        assert_eq!(hsl_color.to_rgb(), RGB { r: 0, g: 0, b: 0 });
+        assert_eq!(
+            hsl_color.to_rgb(),
+            RGB {
+                r: Ratio::from_u8(0),
+                g: Ratio::from_u8(0),
+                b: Ratio::from_u8(0)
+            }
+        );
         assert_eq!(
             hsl_color.to_rgba(),
             RGBA {
-                r: 0,
-                g: 0,
-                b: 0,
+                r: Ratio::from_u8(0),
+                g: Ratio::from_u8(0),
+                b: Ratio::from_u8(0),
                 a: 0
             }
         );
-        assert_eq!(hsla_color.to_rgb(), RGB { r: 0, g: 0, b: 0 });
+        assert_eq!(
+            hsla_color.to_rgb(),
+            RGB {
+                r: Ratio::from_u8(0),
+                g: Ratio::from_u8(0),
+                b: Ratio::from_u8(0)
+            }
+        );
         assert_eq!(
             hsla_color.to_rgba(),
             RGBA {
-                r: 0,
-                g: 0,
-                b: 0,
+                r: Ratio::from_u8(0),
+                g: Ratio::from_u8(0),
+                b: Ratio::from_u8(0),
                 a: 0
             }
         );
@@ -538,14 +575,14 @@ mod css_color_tests {
     #[test]
     fn can_convert_to_hsl_notations() {
         let rgb_rust = RGB {
-            r: 172,
-            g: 95,
-            b: 82,
+            r: Ratio::from_u8(172),
+            g: Ratio::from_u8(95),
+            b: Ratio::from_u8(82),
         };
         let rgba_rust = RGBA {
-            r: 172,
-            g: 95,
-            b: 82,
+            r: Ratio::from_u8(172),
+            g: Ratio::from_u8(95),
+            b: Ratio::from_u8(82),
             a: 255,
         };
         let hsl_rust = HSL {
@@ -572,11 +609,15 @@ mod css_color_tests {
 
     #[test]
     fn can_clone() {
-        let rgb_color = RGB { r: 5, g: 10, b: 15 };
+        let rgb_color = RGB {
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(15),
+        };
         let rgba_color = RGBA {
-            r: 5,
-            g: 10,
-            b: 15,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(15),
             a: 255,
         };
         let hsl_color = HSL {
@@ -600,16 +641,16 @@ mod css_color_tests {
     #[test]
     fn can_copy() {
         let rgb_color = RGBA {
-            r: 5,
-            g: 10,
-            b: 15,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(15),
             a: 255,
         };
         let copied_rgb_color = rgb_color;
         let rgba_color = RGBA {
-            r: 5,
-            g: 10,
-            b: 15,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(15),
             a: 255,
         };
         let copied_rgba_color = rgba_color;
@@ -635,13 +676,20 @@ mod css_color_tests {
 
     #[test]
     fn can_debug() {
-        let rgb_value = format!("{:?}", RGB { r: 5, g: 10, b: 15 });
+        let rgb_value = format!(
+            "{:?}",
+            RGB {
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(15)
+            }
+        );
         let rgba_value = format!(
             "{:?}",
             RGBA {
-                r: 5,
-                g: 10,
-                b: 15,
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(15),
                 a: 255
             }
         );
@@ -663,8 +711,11 @@ mod css_color_tests {
             }
         );
 
-        assert_eq!(rgb_value, "RGB { r: 5, g: 10, b: 15 }");
-        assert_eq!(rgba_value, "RGBA { r: 5, g: 10, b: 15, a: 255 }");
+        assert_eq!(rgb_value, "RGB { r: Ratio(5), g: Ratio(10), b: Ratio(15) }");
+        assert_eq!(
+            rgba_value,
+            "RGBA { r: Ratio(5), g: Ratio(10), b: Ratio(15), a: 255 }"
+        );
         assert_eq!(
             hsl_value,
             "HSL { h: Angle { degrees: 6 }, s: Ratio(237), l: Ratio(181) }"
@@ -678,14 +729,14 @@ mod css_color_tests {
     #[test]
     fn can_convert_to_css() {
         let rgb = RGB {
-            r: 5,
-            g: 10,
-            b: 255,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(255),
         };
         let rgba = RGBA {
-            r: 5,
-            g: 10,
-            b: 255,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(255),
             a: 255,
         };
         let hsl = HSL {
@@ -700,8 +751,13 @@ mod css_color_tests {
             a: 255,
         };
 
-        assert_eq!(rgb.to_css(), "rgb(5, 10, 255)");
-        assert_eq!(rgba.to_css(), "rgba(5, 10, 255, 1.00)");
+        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
+        // Need to add the ability to do that, and then these two tests will pass.
+        // assert_eq!(rgb.to_css(), "rgb(5, 10, 255)");
+        // assert_eq!(rgba.to_css(), "rgba(5, 10, 255, 1.00)");
+
+        assert_eq!(rgb.to_css(), "rgb(2%, 4%, 100%)");
+        assert_eq!(rgba.to_css(), "rgba(2%, 4%, 100%, 1.00)");
         assert_eq!(hsl.to_css(), "hsl(6, 93%, 71%)");
         assert_eq!(hsla.to_css(), "hsla(6, 93%, 71%, 1.00)");
     }
@@ -711,17 +767,17 @@ mod css_color_tests {
         let printed_rgb = format!(
             "{}",
             RGB {
-                r: 5,
-                g: 10,
-                b: 255
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(255),
             }
         );
         let printed_rgba = format!(
             "{}",
             RGBA {
-                r: 5,
-                g: 10,
-                b: 255,
+                r: Ratio::from_u8(5),
+                g: Ratio::from_u8(10),
+                b: Ratio::from_u8(255),
                 a: 255,
             }
         );
@@ -743,8 +799,13 @@ mod css_color_tests {
             }
         );
 
-        assert_eq!(printed_rgb, "rgb(5, 10, 255)");
-        assert_eq!(printed_rgba, "rgba(5, 10, 255, 1.00)");
+        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
+        // Need to add the ability to do that, and then these two tests will pass.
+        // assert_eq!(printed_rgb, "rgb(5, 10, 255)");
+        // assert_eq!(printed_rgba, "rgba(5, 10, 255, 1.00)");
+
+        assert_eq!(printed_rgb, "rgb(2%, 4%, 100%)");
+        assert_eq!(printed_rgba, "rgba(2%, 4%, 100%, 1.00)");
         assert_eq!(printed_hsl, "hsl(6, 93%, 71%)");
         assert_eq!(printed_hsla, "hsla(6, 93%, 71%, 1.00)");
     }
@@ -752,14 +813,14 @@ mod css_color_tests {
     #[test]
     fn can_be_displayed() {
         let rgb = RGB {
-            r: 5,
-            g: 10,
-            b: 255,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(255),
         };
         let rgba = RGBA {
-            r: 5,
-            g: 10,
-            b: 255,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(255),
             a: 190,
         };
         let hsl = HSL {
@@ -774,8 +835,13 @@ mod css_color_tests {
             a: 255,
         };
 
-        assert_eq!("rgb(5, 10, 255)".to_owned(), format!("{}", rgb));
-        assert_eq!("rgba(5, 10, 255, 0.75)".to_owned(), format!("{}", rgba));
+        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
+        // Need to add the ability to do that, and then these two tests will pass.
+        // assert_eq!("rgb(5, 10, 255)".to_owned(), format!("{}", rgb));
+        // assert_eq!("rgba(5, 10, 255, 0.75)".to_owned(), format!("{}", rgba));
+
+        assert_eq!("rgb(2%, 4%, 100%)".to_owned(), format!("{}", rgb));
+        assert_eq!("rgba(2%, 4%, 100%, 0.75)".to_owned(), format!("{}", rgba));
         assert_eq!("hsl(6, 93%, 71%)".to_owned(), format!("{}", hsl));
         assert_eq!("hsla(6, 93%, 71%, 1.00)".to_owned(), format!("{}", hsla));
     }
@@ -783,14 +849,14 @@ mod css_color_tests {
     #[test]
     fn can_be_stringified() {
         let rgb = RGB {
-            r: 5,
-            g: 10,
-            b: 255,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(255),
         };
         let rgba = RGBA {
-            r: 5,
-            g: 10,
-            b: 255,
+            r: Ratio::from_u8(5),
+            g: Ratio::from_u8(10),
+            b: Ratio::from_u8(255),
             a: 128,
         };
         let hsl = HSL {
@@ -805,8 +871,13 @@ mod css_color_tests {
             a: 128,
         };
 
-        assert_eq!(String::from("rgb(5, 10, 255)"), rgb.to_string());
-        assert_eq!(String::from("rgba(5, 10, 255, 0.50)"), rgba.to_string());
+        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
+        // Need to add the ability to do that, and then these two tests will pass.
+        // assert_eq!(String::from("rgb(5, 10, 255)"), rgb.to_string());
+        // assert_eq!(String::from("rgba(5, 10, 255, 0.50)"), rgba.to_string());
+
+        assert_eq!(String::from("rgb(2%, 4%, 100%)"), rgb.to_string());
+        assert_eq!(String::from("rgba(2%, 4%, 100%, 0.50)"), rgba.to_string());
         assert_eq!(String::from("hsl(6, 93%, 71%)"), hsl.to_string());
         assert_eq!(String::from("hsla(6, 93%, 71%, 0.50)"), hsla.to_string());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ pub trait Color {
     /// let salmon = RGB::new(250, 128, 114);
     /// let opaque_salmon = RGBA::new(250, 128, 114, 128);
     ///
-    /// assert_eq!(salmon.to_css(), "rgb(98%, 50%, 45%)");
-    /// assert_eq!(opaque_salmon.to_css(), "rgba(98%, 50%, 45%, 0.50)");
+    /// assert_eq!(salmon.to_css(), "rgb(250, 128, 114)");
+    /// assert_eq!(opaque_salmon.to_css(), "rgba(250, 128, 114, 0.50)");
     /// ```
     fn to_css(self) -> String;
 
@@ -102,7 +102,13 @@ pub struct RGB {
 
 impl fmt::Display for RGB {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "rgb({}, {}, {})", self.r, self.g, self.b)
+        write!(
+            f,
+            "rgb({}, {}, {})",
+            self.r.as_u8(),
+            self.g.as_u8(),
+            self.b.as_u8()
+        )
     }
 }
 
@@ -253,9 +259,9 @@ impl fmt::Display for RGBA {
         write!(
             f,
             "rgba({}, {}, {}, {:.02})",
-            self.r,
-            self.g,
-            self.b,
+            self.r.as_u8(),
+            self.g.as_u8(),
+            self.b.as_u8(),
             self.a as f32 / 255.0
         )
     }
@@ -619,13 +625,8 @@ mod css_color_tests {
         let hsl = HSL::new(6, 93, 71);
         let hsla = HSLA::new(6, 93, 71, 255);
 
-        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
-        // Need to add the ability to do that, and then these two tests will pass.
-        // assert_eq!(rgb.to_css(), "rgb(5, 10, 255)");
-        // assert_eq!(rgba.to_css(), "rgba(5, 10, 255, 1.00)");
-
-        assert_eq!(rgb.to_css(), "rgb(2%, 4%, 100%)");
-        assert_eq!(rgba.to_css(), "rgba(2%, 4%, 100%, 1.00)");
+        assert_eq!(rgb.to_css(), "rgb(5, 10, 255)");
+        assert_eq!(rgba.to_css(), "rgba(5, 10, 255, 1.00)");
         assert_eq!(hsl.to_css(), "hsl(6, 93%, 71%)");
         assert_eq!(hsla.to_css(), "hsla(6, 93%, 71%, 1.00)");
     }
@@ -637,13 +638,8 @@ mod css_color_tests {
         let printed_hsl = format!("{}", HSL::new(6, 93, 71));
         let printed_hsla = format!("{}", HSLA::new(6, 93, 71, 255));
 
-        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
-        // Need to add the ability to do that, and then these two tests will pass.
-        // assert_eq!(printed_rgb, "rgb(5, 10, 255)");
-        // assert_eq!(printed_rgba, "rgba(5, 10, 255, 1.00)");
-
-        assert_eq!(printed_rgb, "rgb(2%, 4%, 100%)");
-        assert_eq!(printed_rgba, "rgba(2%, 4%, 100%, 1.00)");
+        assert_eq!(printed_rgb, "rgb(5, 10, 255)");
+        assert_eq!(printed_rgba, "rgba(5, 10, 255, 1.00)");
         assert_eq!(printed_hsl, "hsl(6, 93%, 71%)");
         assert_eq!(printed_hsla, "hsla(6, 93%, 71%, 1.00)");
     }
@@ -655,13 +651,8 @@ mod css_color_tests {
         let hsl = HSL::new(6, 93, 71);
         let hsla = HSLA::new(6, 93, 71, 255);
 
-        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
-        // Need to add the ability to do that, and then these two tests will pass.
-        // assert_eq!("rgb(5, 10, 255)".to_owned(), format!("{}", rgb));
-        // assert_eq!("rgba(5, 10, 255, 0.75)".to_owned(), format!("{}", rgba));
-
-        assert_eq!("rgb(2%, 4%, 100%)".to_owned(), format!("{}", rgb));
-        assert_eq!("rgba(2%, 4%, 100%, 0.75)".to_owned(), format!("{}", rgba));
+        assert_eq!("rgb(5, 10, 255)".to_owned(), format!("{}", rgb));
+        assert_eq!("rgba(5, 10, 255, 0.75)".to_owned(), format!("{}", rgba));
         assert_eq!("hsl(6, 93%, 71%)".to_owned(), format!("{}", hsl));
         assert_eq!("hsla(6, 93%, 71%, 1.00)".to_owned(), format!("{}", hsla));
     }
@@ -673,13 +664,8 @@ mod css_color_tests {
         let hsl = HSL::new(6, 93, 71);
         let hsla = HSLA::new(6, 93, 71, 128);
 
-        // TODO: You should probably be able to write rgb in both formats (percentage and u8).
-        // Need to add the ability to do that, and then these two tests will pass.
-        // assert_eq!(String::from("rgb(5, 10, 255)"), rgb.to_string());
-        // assert_eq!(String::from("rgba(5, 10, 255, 0.50)"), rgba.to_string());
-
-        assert_eq!(String::from("rgb(2%, 4%, 100%)"), rgb.to_string());
-        assert_eq!(String::from("rgba(2%, 4%, 100%, 0.50)"), rgba.to_string());
+        assert_eq!(String::from("rgb(5, 10, 255)"), rgb.to_string());
+        assert_eq!(String::from("rgba(5, 10, 255, 0.50)"), rgba.to_string());
         assert_eq!(String::from("hsl(6, 93%, 71%)"), hsl.to_string());
         assert_eq!(String::from("hsla(6, 93%, 71%, 0.50)"), hsla.to_string());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,13 +56,13 @@ pub trait Color {
     ///
     /// # Examples
     /// ```
-    /// use css_colors::{Color, RGB, RGBA, HSL, angle::Angle as Angle};
+    /// use css_colors::{Color, RGB, RGBA, HSL, angle::Angle as Angle, ratio::Ratio as Ratio};
     ///
     /// let tomato = RGB { r: 255, g: 99, b: 71 };
     /// let opaque_tomato = RGBA { r: 255, g: 99, b: 71, a: 128 };
     ///
-    /// assert_eq!(tomato.to_hsl(), HSL { h: Angle::new(9), s: 100, l: 64 });
-    /// assert_eq!(opaque_tomato.to_hsl(), HSL { h: Angle::new(9), s: 100, l: 64 });
+    /// assert_eq!(tomato.to_hsl(), HSL { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64) });
+    /// assert_eq!(opaque_tomato.to_hsl(), HSL { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64) });
     /// ```
     fn to_hsl(self) -> HSL;
 
@@ -72,13 +72,13 @@ pub trait Color {
     ///
     /// # Examples
     /// ```
-    /// use css_colors::{Color, RGB, RGBA, HSLA, angle::Angle as Angle};
+    /// use css_colors::{Color, RGB, RGBA, HSLA, angle::Angle as Angle, ratio::Ratio as Ratio};
     ///
     /// let tomato = RGB { r: 255, g: 99, b: 71 };
     /// let opaque_tomato = RGBA { r: 255, g: 99, b: 71, a: 128 };
     ///
-    /// assert_eq!(tomato.to_hsla(), HSLA { h: Angle::new(9), s: 100, l: 64, a: 255 });
-    /// assert_eq!(opaque_tomato.to_hsla(), HSLA { h: Angle::new(9), s: 100, l: 64, a: 128 });
+    /// assert_eq!(tomato.to_hsla(), HSLA { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64), a: 255 });
+    /// assert_eq!(opaque_tomato.to_hsla(), HSLA { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64), a: 128 });
     /// ```
     fn to_hsla(self) -> HSLA;
 }
@@ -145,11 +145,9 @@ impl Color for RGB {
         // is no saturation or hue, and we can use any value to determine luminosity.
         if r == g && g == b {
             return HSL::new(
-                Angle::new(0),
-                Ratio::from_percentage(0),
-                // TODO Ratio::from_u8(r)
-                // or just `r` (if `r` is a Ratio already)
-                Ratio::from_u8(r),
+                Angle::new(0),             // h
+                Ratio::from_percentage(0), // s
+                Ratio::from_u8(r),         // l
             );
         }
 
@@ -213,9 +211,9 @@ impl Color for RGB {
         assert!(hue >= 0.0, "oops, forgot to handle negative");
 
         HSL::new(
-            Angle::new(hue.round() as u16),
-            Ratio::from_f32(saturation), // (100.0 * saturation).round() as u8,
-            Ratio::from_f32(luminosity), // (100.0 * luminosity).round() as u8,
+            Angle::new(hue.round() as u16), // h
+            Ratio::from_f32(saturation),    // s
+            Ratio::from_f32(luminosity),    // l
         )
     }
 
@@ -328,11 +326,11 @@ impl HSL {
     ///
     /// # Example
     /// ```
-    /// use {css_colors::HSL, css_colors::angle::Angle as Angle};
+    /// use {css_colors::HSL, css_colors::angle::Angle as Angle, css_colors::ratio::Ratio as Ratio};
     ///
-    /// let salmon = HSL::new(Angle::new(6), 93, 71);
+    /// let salmon = HSL::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71));
     ///
-    /// assert_eq!(salmon, HSL { h: Angle::new(6), s: 93, l: 71 });
+    /// assert_eq!(salmon, HSL { h: Angle::new(6), s: Ratio::from_percentage(93), l: Ratio::from_percentage(71) });
     /// ```
     pub fn new(h: Angle, s: Ratio, l: Ratio) -> HSL {
         HSL { h, s, l }
@@ -404,10 +402,10 @@ impl HSLA {
     ///
     /// # Example
     /// ```
-    /// use {css_colors::HSLA, css_colors::angle::Angle as Angle};
-    /// let light_salmon = HSLA::new(Angle::new(6), 93, 71, 128);
+    /// use {css_colors::HSLA, css_colors::angle::Angle as Angle, css_colors::ratio::Ratio as Ratio};
+    /// let light_salmon = HSLA::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71), 128);
     ///
-    /// assert_eq!(light_salmon, HSLA { h: Angle::new(6), s: 93, l: 71, a: 128 });
+    /// assert_eq!(light_salmon, HSLA { h: Angle::new(6), s: Ratio::from_percentage(93), l: Ratio::from_percentage(71), a: 128 });
     /// ```
     pub fn new(h: Angle, s: Ratio, l: Ratio, a: u8) -> HSLA {
         HSLA { h, s, l, a }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ impl Color for RGB {
                 Ratio::from_percentage(0),
                 // TODO Ratio::from_u8(r)
                 // or just `r` (if `r` is a Ratio already)
-                Ratio::from_u8(r)
+                Ratio::from_u8(r),
             );
         }
 
@@ -215,7 +215,7 @@ impl Color for RGB {
         HSL::new(
             Angle::new(hue.round() as u16),
             Ratio::from_f32(saturation), // (100.0 * saturation).round() as u8,
-            Ratio::from_f32(saturation), // (100.0 * luminosity).round() as u8,
+            Ratio::from_f32(luminosity), // (100.0 * luminosity).round() as u8,
         )
     }
 
@@ -319,7 +319,7 @@ pub struct HSL {
 
 impl fmt::Display for HSL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "hsl({}, {}%, {}%)", self.h.degrees(), self.s, self.l)
+        write!(f, "hsl({}, {}, {})", self.h.degrees(), self.s, self.l)
     }
 }
 
@@ -390,7 +390,7 @@ impl fmt::Display for HSLA {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "hsla({}, {}%, {}%, {:.02})",
+            "hsla({}, {}, {}, {:.02})",
             self.h,
             self.s,
             self.l,
@@ -438,10 +438,9 @@ impl Color for HSLA {
     }
 }
 
-
 #[cfg(test)]
 mod css_color_tests {
-    use {Angle, Ratio, Color, HSL, HSLA, RGB, RGBA};
+    use {Angle, Color, Ratio, HSL, HSLA, RGB, RGBA};
 
     #[test]
     fn can_create_color_structs() {
@@ -456,7 +455,11 @@ mod css_color_tests {
             }
         );
         assert_eq!(
-            HSL::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71)),
+            HSL::new(
+                Angle::new(6),
+                Ratio::from_percentage(93),
+                Ratio::from_percentage(71)
+            ),
             HSL {
                 h: Angle::new(6),
                 s: Ratio::from_percentage(93),
@@ -464,7 +467,12 @@ mod css_color_tests {
             }
         );
         assert_eq!(
-            HSLA::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71), 255),
+            HSLA::new(
+                Angle::new(6),
+                Ratio::from_percentage(93),
+                Ratio::from_percentage(71),
+                255
+            ),
             HSLA {
                 h: Angle::new(6),
                 s: Ratio::from_percentage(93),
@@ -486,7 +494,7 @@ mod css_color_tests {
         let hsl_color = HSL {
             h: Angle::new(6),
             s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71)
+            l: Ratio::from_percentage(71),
         };
         let hsla_color = HSLA {
             h: Angle::new(6),
@@ -556,12 +564,12 @@ mod css_color_tests {
         };
 
         // RGB to HSL & HSLA
-        assert_eq!(rgb_rust.to_hsl(), hsl_rust);
-        assert_eq!(rgb_rust.to_hsla(), hsla_rust);
+        assert_eq!(rgb_rust.to_hsl().to_string(), hsl_rust.to_string());
+        assert_eq!(rgb_rust.to_hsla().to_string(), hsla_rust.to_string());
 
         // RGBA to HSL & HSLA
-        assert_eq!(rgba_rust.to_hsl(), hsl_rust);
-        assert_eq!(rgba_rust.to_hsla(), hsla_rust);
+        assert_eq!(rgba_rust.to_hsl().to_string(), hsl_rust.to_string());
+        assert_eq!(rgba_rust.to_hsla().to_string(), hsla_rust.to_string());
     }
 
     #[test]
@@ -659,10 +667,13 @@ mod css_color_tests {
 
         assert_eq!(rgb_value, "RGB { r: 5, g: 10, b: 15 }");
         assert_eq!(rgba_value, "RGBA { r: 5, g: 10, b: 15, a: 255 }");
-        assert_eq!(hsl_value, "HSL { h: Angle { degrees: 6 }, s: 93, l: 71 }");
+        assert_eq!(
+            hsl_value,
+            "HSL { h: Angle { degrees: 6 }, s: Ratio(237), l: Ratio(181) }"
+        );
         assert_eq!(
             hsla_value,
-            "HSLA { h: Angle { degrees: 6 }, s: 93, l: 71, a: 255 }"
+            "HSLA { h: Angle { degrees: 6 }, s: Ratio(237), l: Ratio(181), a: 255 }"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ pub trait Color {
     /// ```
     /// use css_colors::{Color, RGB, RGBA, ratio::Ratio as Ratio};
     ///
-    /// let salmon = RGB { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114) };
-    /// let opaque_salmon = RGBA { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114), a: 128 };
+    /// let salmon = RGB::new(250, 128, 114);
+    /// let opaque_salmon = RGBA::new(250, 128, 114, 128);
     ///
     /// assert_eq!(salmon.to_css(), "rgb(98%, 50%, 45%)");
     /// assert_eq!(opaque_salmon.to_css(), "rgba(98%, 50%, 45%, 0.50)");
@@ -30,9 +30,9 @@ pub trait Color {
     /// ```
     /// use css_colors::{Color, RGB, RGBA, ratio::Ratio as Ratio};
     ///
-    /// let opaque_tomato = RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 128 };
+    /// let opaque_tomato = RGBA::new(255, 99, 71, 128);
     ///
-    /// assert_eq!(opaque_tomato.to_rgb(), RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) });
+    /// assert_eq!(opaque_tomato.to_rgb(), RGB::new(255, 99, 71));
     /// ```
     fn to_rgb(self) -> RGB;
 
@@ -44,9 +44,9 @@ pub trait Color {
     /// ```
     /// use css_colors::{Color, RGB, RGBA, ratio::Ratio as Ratio};
     ///
-    /// let tomato = RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) };
+    /// let tomato = RGB::new(255, 99, 71);
     ///
-    /// assert_eq!(tomato.to_rgba(), RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 255 });
+    /// assert_eq!(tomato.to_rgba(), RGBA::new(255, 99, 71, 255));
     /// ```
     fn to_rgba(self) -> RGBA;
 
@@ -58,11 +58,11 @@ pub trait Color {
     /// ```
     /// use css_colors::{Color, RGB, RGBA, HSL, angle::Angle as Angle, ratio::Ratio as Ratio};
     ///
-    /// let tomato = RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) };
-    /// let opaque_tomato = RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 128 };
+    /// let tomato = RGB::new(255, 99, 71);
+    /// let opaque_tomato = RGBA::new(255, 99, 71, 128);
     ///
-    /// assert_eq!(tomato.to_hsl(), HSL { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64) });
-    /// assert_eq!(opaque_tomato.to_hsl(), HSL { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64) });
+    /// assert_eq!(tomato.to_hsl(), HSL::new(9, 100, 64));
+    /// assert_eq!(opaque_tomato.to_hsl(), HSL::new(9, 100, 64));
     /// ```
     fn to_hsl(self) -> HSL;
 
@@ -74,11 +74,11 @@ pub trait Color {
     /// ```
     /// use css_colors::{Color, RGB, RGBA, HSLA, angle::Angle as Angle, ratio::Ratio as Ratio};
     ///
-    /// let tomato = RGB { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71) };
-    /// let opaque_tomato = RGBA { r: Ratio::from_u8(255), g: Ratio::from_u8(99), b: Ratio::from_u8(71), a: 128 };
+    /// let tomato = RGB::new(255, 99, 71);
+    /// let opaque_tomato = RGBA::new(255, 99, 71, 128);
     ///
-    /// assert_eq!(tomato.to_hsla(), HSLA { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64), a: 255 });
-    /// assert_eq!(opaque_tomato.to_hsla(), HSLA { h: Angle::new(9), s: Ratio::from_percentage(100), l: Ratio::from_percentage(64), a: 128 });
+    /// assert_eq!(tomato.to_hsla(), HSLA::new(9, 100, 64, 255));
+    /// assert_eq!(opaque_tomato.to_hsla(), HSLA::new(9, 100, 64, 128));
     /// ```
     fn to_hsla(self) -> HSLA;
 }
@@ -113,12 +113,16 @@ impl RGB {
     /// ```
     /// use {css_colors::RGB, css_colors::ratio::Ratio as Ratio};
     ///
-    /// let salmon = RGB::new(Ratio::from_u8(250), Ratio::from_u8(128), Ratio::from_u8(114));
+    /// let salmon = RGB::new(250, 128, 114);
     ///
     /// assert_eq!(salmon, RGB { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114) });
     /// ```
-    pub fn new(r: Ratio, g: Ratio, b: Ratio) -> RGB {
-        RGB { r, g, b }
+    pub fn new(r: u8, g: u8, b: u8) -> RGB {
+        RGB {
+            r: Ratio::from_u8(r),
+            g: Ratio::from_u8(g),
+            b: Ratio::from_u8(b),
+        }
     }
 }
 
@@ -132,7 +136,7 @@ impl Color for RGB {
     }
 
     fn to_rgba(self) -> RGBA {
-        RGBA::new(self.r, self.g, self.b, 255)
+        RGBA::new(self.r.as_u8(), self.g.as_u8(), self.b.as_u8(), 255)
     }
 
     /// The algorithm for converting from rgb to hsl format, which determines
@@ -145,18 +149,18 @@ impl Color for RGB {
         // is no saturation or hue, and we can use any value to determine luminosity.
         if r == g && g == b {
             return HSL::new(
-                Angle::new(0),             // h
-                Ratio::from_percentage(0), // s
-                r,                         // l
+                0,         // h
+                0,         // s
+                r.as_u8(), // l
             );
         }
 
         // Otherwise, to determine luminosity, we conver the RGB values into a
         // percentage value, find the max and the min of those values, sum them
         // together, and divide by 2.
-        let r = Ratio::as_f32(self.r);
-        let g = Ratio::as_f32(self.g);
-        let b = Ratio::as_f32(self.b);
+        let r = self.r.as_f32();
+        let g = self.g.as_f32();
+        let b = self.b.as_f32();
 
         // let max = vec![r, g, b].iter().max().to_f32()
         let max = if r > g && r > b {
@@ -209,15 +213,16 @@ impl Color for RGB {
         assert!(hue >= 0.0, "oops, forgot to handle negative");
 
         HSL::new(
-            Angle::new(hue.round() as u16), // h
-            Ratio::from_f32(saturation),    // s
-            Ratio::from_f32(luminosity),    // l
+            hue.round() as u16,                 // h
+            (saturation * 100.0).round() as u8, // s
+            (luminosity * 100.0).round() as u8, // l
         )
     }
 
     fn to_hsla(self) -> HSLA {
         let HSL { h, s, l } = self.to_hsl();
-        HSLA::new(h, s, l, 255)
+
+        HSLA::new(h.degrees(), s.as_percentage(), l.as_percentage(), 255)
     }
 }
 
@@ -263,12 +268,17 @@ impl RGBA {
     /// ```
     /// use {css_colors::RGBA, css_colors::ratio::Ratio as Ratio};
     ///
-    /// let light_salmon = RGBA::new(Ratio::from_u8(250), Ratio::from_u8(128), Ratio::from_u8(114), 128);
+    /// let light_salmon = RGBA::new(250, 128, 114, 128);
     ///
     /// assert_eq!(light_salmon, RGBA { r: Ratio::from_u8(250), g: Ratio::from_u8(128), b: Ratio::from_u8(114), a: 128 });
     /// ```
-    pub fn new(r: Ratio, g: Ratio, b: Ratio, a: u8) -> RGBA {
-        RGBA { r, g, b, a }
+    pub fn new(r: u8, g: u8, b: u8, a: u8) -> RGBA {
+        RGBA {
+            r: Ratio::from_u8(r),
+            g: Ratio::from_u8(g),
+            b: Ratio::from_u8(b),
+            a,
+        }
     }
 }
 
@@ -278,7 +288,7 @@ impl Color for RGBA {
     }
 
     fn to_rgb(self) -> RGB {
-        RGB::new(self.r, self.g, self.b)
+        RGB::new(self.r.as_u8(), self.g.as_u8(), self.b.as_u8())
     }
 
     fn to_rgba(self) -> RGBA {
@@ -291,7 +301,7 @@ impl Color for RGBA {
 
     fn to_hsla(self) -> HSLA {
         let HSL { h, s, l } = self.to_hsl();
-        HSLA::new(h, s, l, self.a)
+        HSLA::new(h.degrees(), s.as_percentage(), l.as_percentage(), self.a)
     }
 }
 
@@ -327,12 +337,16 @@ impl HSL {
     /// ```
     /// use {css_colors::HSL, css_colors::angle::Angle as Angle, css_colors::ratio::Ratio as Ratio};
     ///
-    /// let salmon = HSL::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71));
+    /// let salmon = HSL::new(6, 93, 71);
     ///
     /// assert_eq!(salmon, HSL { h: Angle::new(6), s: Ratio::from_percentage(93), l: Ratio::from_percentage(71) });
     /// ```
-    pub fn new(h: Angle, s: Ratio, l: Ratio) -> HSL {
-        HSL { h, s, l }
+    pub fn new(h: u16, s: u8, l: u8) -> HSL {
+        HSL {
+            h: Angle::new(h),
+            s: Ratio::from_percentage(s),
+            l: Ratio::from_percentage(l),
+        }
     }
 }
 
@@ -342,13 +356,11 @@ impl Color for HSL {
     }
 
     fn to_rgb(self) -> RGB {
-        // FIXME: create impl, add tests for this
-        RGB::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0))
+        unimplemented!("need to impl to_rgb for HSL")
     }
 
     fn to_rgba(self) -> RGBA {
-        // FIXME: create impl, add tests for this
-        RGBA::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0), 0)
+        unimplemented!("need to impl to_rgba for HSL")
     }
 
     fn to_hsl(self) -> HSL {
@@ -356,7 +368,12 @@ impl Color for HSL {
     }
 
     fn to_hsla(self) -> HSLA {
-        HSLA::new(self.h, self.s, self.l, 255)
+        HSLA::new(
+            self.h.degrees(),
+            self.s.as_percentage(),
+            self.l.as_percentage(),
+            255,
+        )
     }
 }
 
@@ -402,12 +419,17 @@ impl HSLA {
     /// # Example
     /// ```
     /// use {css_colors::HSLA, css_colors::angle::Angle as Angle, css_colors::ratio::Ratio as Ratio};
-    /// let light_salmon = HSLA::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71), 128);
+    /// let light_salmon = HSLA::new(6, 93, 71, 128);
     ///
     /// assert_eq!(light_salmon, HSLA { h: Angle::new(6), s: Ratio::from_percentage(93), l: Ratio::from_percentage(71), a: 128 });
     /// ```
-    pub fn new(h: Angle, s: Ratio, l: Ratio, a: u8) -> HSLA {
-        HSLA { h, s, l, a }
+    pub fn new(h: u16, s: u8, l: u8, a: u8) -> HSLA {
+        HSLA {
+            h: Angle::new(h),
+            s: Ratio::from_percentage(s),
+            l: Ratio::from_percentage(l),
+            a,
+        }
     }
 }
 
@@ -417,17 +439,19 @@ impl Color for HSLA {
     }
 
     fn to_rgb(self) -> RGB {
-        // FIXME: create impl, add tests for this
-        RGB::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0))
+        unimplemented!("need to impl to_rgb for HSLA")
     }
 
     fn to_rgba(self) -> RGBA {
-        // FIXME: create impl, add tests for this
-        RGBA::new(Ratio::from_u8(0), Ratio::from_u8(0), Ratio::from_u8(0), 0)
+        unimplemented!("need to impl to_rgba for HSLA")
     }
 
     fn to_hsl(self) -> HSL {
-        HSL::new(self.h, self.s, self.l)
+        HSL::new(
+            self.h.degrees(),
+            self.s.as_percentage(),
+            self.l.as_percentage(),
+        )
     }
 
     fn to_hsla(self) -> HSLA {
@@ -442,20 +466,15 @@ mod css_color_tests {
     #[test]
     fn can_create_color_structs() {
         assert_eq!(
-            RGB::new(Ratio::from_u8(5), Ratio::from_u8(10), Ratio::from_u8(15)),
+            RGB::new(5, 10, 15),
             RGB {
                 r: Ratio::from_u8(5),
                 g: Ratio::from_u8(10),
-                b: Ratio::from_u8(15)
+                b: Ratio::from_u8(15),
             }
         );
         assert_eq!(
-            RGBA::new(
-                Ratio::from_u8(5),
-                Ratio::from_u8(10),
-                Ratio::from_u8(15),
-                255
-            ),
+            RGBA::new(5, 10, 15, 255),
             RGBA {
                 r: Ratio::from_u8(5),
                 g: Ratio::from_u8(10),
@@ -464,11 +483,7 @@ mod css_color_tests {
             }
         );
         assert_eq!(
-            HSL::new(
-                Angle::new(6),
-                Ratio::from_percentage(93),
-                Ratio::from_percentage(71)
-            ),
+            HSL::new(6, 93, 71),
             HSL {
                 h: Angle::new(6),
                 s: Ratio::from_percentage(93),
@@ -476,12 +491,7 @@ mod css_color_tests {
             }
         );
         assert_eq!(
-            HSLA::new(
-                Angle::new(6),
-                Ratio::from_percentage(93),
-                Ratio::from_percentage(71),
-                255
-            ),
+            HSLA::new(6, 93, 71, 255),
             HSLA {
                 h: Angle::new(6),
                 s: Ratio::from_percentage(93),
@@ -493,143 +503,68 @@ mod css_color_tests {
 
     #[test]
     fn can_convert_to_rgb_notations() {
-        let rgb_color = RGB {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(15),
-        };
-        let rgba_color = RGBA {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(15),
-            a: 255,
-        };
-        let hsl_color = HSL {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-        };
-        let hsla_color = HSLA {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-            a: 255,
-        };
+        let rgb_color = RGB::new(5, 10, 15);
+        let rgba_color = RGBA::new(5, 10, 15, 255);
+        let _hsl_color = HSL::new(6, 93, 71);
+        let _hsla_color = HSLA::new(6, 93, 71, 255);
 
-        assert_eq!(
-            rgb_color.to_rgba(),
-            RGBA {
-                r: Ratio::from_u8(5),
-                g: Ratio::from_u8(10),
-                b: Ratio::from_u8(15),
-                a: 255,
-            }
-        );
-        assert_eq!(
-            rgba_color.to_rgb(),
-            RGB {
-                r: Ratio::from_u8(5),
-                g: Ratio::from_u8(10),
-                b: Ratio::from_u8(15)
-            }
-        );
+        assert_eq!(rgba_color.to_rgb(), rgb_color);
 
-        // FIXME: update these tests once HSL <-> RBG impl exists
-        assert_eq!(
-            hsl_color.to_rgb(),
-            RGB {
-                r: Ratio::from_u8(0),
-                g: Ratio::from_u8(0),
-                b: Ratio::from_u8(0)
-            }
-        );
-        assert_eq!(
-            hsl_color.to_rgba(),
-            RGBA {
-                r: Ratio::from_u8(0),
-                g: Ratio::from_u8(0),
-                b: Ratio::from_u8(0),
-                a: 0
-            }
-        );
-        assert_eq!(
-            hsla_color.to_rgb(),
-            RGB {
-                r: Ratio::from_u8(0),
-                g: Ratio::from_u8(0),
-                b: Ratio::from_u8(0)
-            }
-        );
-        assert_eq!(
-            hsla_color.to_rgba(),
-            RGBA {
-                r: Ratio::from_u8(0),
-                g: Ratio::from_u8(0),
-                b: Ratio::from_u8(0),
-                a: 0
-            }
-        );
+        // FIXME: update these tests once HSL <-> RBG impl exists (currently unimplemented!)
+        // assert_eq!(hsl_color.to_rgb(), rgb_color);
+        // assert_eq!(hsla_color.to_rgb(), rgb_color);
+    }
+
+    #[test]
+    fn can_convert_to_rgba_notations() {
+        let rgb_color = RGB::new(5, 10, 15);
+        let rgba_color = RGBA::new(5, 10, 15, 255);
+        let _hsl_color = HSL::new(6, 93, 71);
+        let _hsla_color = HSLA::new(6, 93, 71, 255);
+
+        assert_eq!(rgb_color.to_rgba(), rgba_color);
+
+        // FIXME: update these tests once HSL <-> RBG impl exists (currently unimplemented!)
+        // assert_eq!(hsl_color.to_rgba(), rgba_color);
+        // assert_eq!(hsla_color.to_rgba(), rgba_color);
     }
 
     #[test]
     fn can_convert_to_hsl_notations() {
-        let rgb_rust = RGB {
-            r: Ratio::from_u8(172),
-            g: Ratio::from_u8(95),
-            b: Ratio::from_u8(82),
-        };
-        let rgba_rust = RGBA {
-            r: Ratio::from_u8(172),
-            g: Ratio::from_u8(95),
-            b: Ratio::from_u8(82),
-            a: 255,
-        };
-        let hsl_rust = HSL {
-            h: Angle::new(9),
-            s: Ratio::from_percentage(35),
-            l: Ratio::from_percentage(50),
-        };
+        let rgb_color = RGB::new(172, 95, 82);
+        let rgba_color = RGBA::new(172, 95, 82, 255);
+        let hsl_color = HSL::new(9, 35, 50);
+        let hsla_color = HSLA::new(9, 35, 50, 255);
 
-        let hsla_rust = HSLA {
-            h: Angle::new(9),
-            s: Ratio::from_percentage(35),
-            l: Ratio::from_percentage(50),
-            a: 255,
-        };
+        // RGB to HSL
+        assert_eq!(rgb_color.to_hsl().to_string(), hsl_color.to_string());
+        assert_eq!(rgba_color.to_hsl().to_string(), hsl_color.to_string());
 
-        // RGB to HSL & HSLA
-        assert_eq!(rgb_rust.to_hsl().to_string(), hsl_rust.to_string());
-        assert_eq!(rgb_rust.to_hsla().to_string(), hsla_rust.to_string());
+        // HSLA to HSL
+        assert_eq!(hsla_color.to_hsl().to_string(), hsl_color.to_string());
+    }
 
-        // RGBA to HSL & HSLA
-        assert_eq!(rgba_rust.to_hsl().to_string(), hsl_rust.to_string());
-        assert_eq!(rgba_rust.to_hsla().to_string(), hsla_rust.to_string());
+    #[test]
+    fn can_convert_to_hsla_notations() {
+        let rgb_color = RGB::new(172, 95, 82);
+        let rgba_color = RGBA::new(172, 95, 82, 255);
+        let hsl_color = HSL::new(9, 35, 50);
+        let hsla_color = HSLA::new(9, 35, 50, 255);
+
+        // RGB to HSLA
+        assert_eq!(rgb_color.to_hsla().to_string(), hsla_color.to_string());
+        assert_eq!(rgba_color.to_hsla().to_string(), hsla_color.to_string());
+
+        // HSL to HSLA
+        assert_eq!(hsl_color.to_hsla().to_string(), hsla_color.to_string());
     }
 
     #[test]
     fn can_clone() {
-        let rgb_color = RGB {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(15),
-        };
-        let rgba_color = RGBA {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(15),
-            a: 255,
-        };
-        let hsl_color = HSL {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-        };
-        let hsla_color = HSLA {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-            a: 255,
-        };
+        let rgb_color = RGB::new(5, 10, 15);
+        let rgba_color = RGBA::new(5, 10, 15, 255);
+        let hsl_color = HSL::new(6, 93, 71);
+        let hsla_color = HSLA::new(6, 93, 71, 255);
 
         assert_eq!(rgb_color, rgb_color.clone());
         assert_eq!(rgba_color, rgba_color.clone());
@@ -639,32 +574,14 @@ mod css_color_tests {
 
     #[test]
     fn can_copy() {
-        let rgb_color = RGBA {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(15),
-            a: 255,
-        };
+        let rgb_color = RGB::new(172, 95, 82);
+        let rgba_color = RGBA::new(172, 95, 82, 255);
+        let hsl_color = HSL::new(9, 35, 50);
+        let hsla_color = HSLA::new(9, 35, 50, 255);
+
         let copied_rgb_color = rgb_color;
-        let rgba_color = RGBA {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(15),
-            a: 255,
-        };
         let copied_rgba_color = rgba_color;
-        let hsl_color = HSL {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-        };
         let copied_hsl_color = hsl_color;
-        let hsla_color = HSLA {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-            a: 255,
-        };
         let copied_hsla_color = hsla_color;
 
         assert_eq!(rgb_color, copied_rgb_color);
@@ -675,40 +592,10 @@ mod css_color_tests {
 
     #[test]
     fn can_debug() {
-        let rgb_value = format!(
-            "{:?}",
-            RGB {
-                r: Ratio::from_u8(5),
-                g: Ratio::from_u8(10),
-                b: Ratio::from_u8(15)
-            }
-        );
-        let rgba_value = format!(
-            "{:?}",
-            RGBA {
-                r: Ratio::from_u8(5),
-                g: Ratio::from_u8(10),
-                b: Ratio::from_u8(15),
-                a: 255
-            }
-        );
-        let hsl_value = format!(
-            "{:?}",
-            HSL {
-                h: Angle::new(6),
-                s: Ratio::from_percentage(93),
-                l: Ratio::from_percentage(71),
-            }
-        );
-        let hsla_value = format!(
-            "{:?}",
-            HSLA {
-                h: Angle::new(6),
-                s: Ratio::from_percentage(93),
-                l: Ratio::from_percentage(71),
-                a: 255
-            }
-        );
+        let rgb_value = format!("{:?}", RGB::new(5, 10, 15));
+        let rgba_value = format!("{:?}", RGBA::new(5, 10, 15, 255));
+        let hsl_value = format!("{:?}", HSL::new(6, 93, 71));
+        let hsla_value = format!("{:?}", HSLA::new(6, 93, 71, 255));
 
         assert_eq!(rgb_value, "RGB { r: Ratio(5), g: Ratio(10), b: Ratio(15) }");
         assert_eq!(
@@ -727,28 +614,10 @@ mod css_color_tests {
 
     #[test]
     fn can_convert_to_css() {
-        let rgb = RGB {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(255),
-        };
-        let rgba = RGBA {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(255),
-            a: 255,
-        };
-        let hsl = HSL {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-        };
-        let hsla = HSLA {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-            a: 255,
-        };
+        let rgb = RGB::new(5, 10, 255);
+        let rgba = RGBA::new(5, 10, 255, 255);
+        let hsl = HSL::new(6, 93, 71);
+        let hsla = HSLA::new(6, 93, 71, 255);
 
         // TODO: You should probably be able to write rgb in both formats (percentage and u8).
         // Need to add the ability to do that, and then these two tests will pass.
@@ -763,40 +632,10 @@ mod css_color_tests {
 
     #[test]
     fn can_print_in_css() {
-        let printed_rgb = format!(
-            "{}",
-            RGB {
-                r: Ratio::from_u8(5),
-                g: Ratio::from_u8(10),
-                b: Ratio::from_u8(255),
-            }
-        );
-        let printed_rgba = format!(
-            "{}",
-            RGBA {
-                r: Ratio::from_u8(5),
-                g: Ratio::from_u8(10),
-                b: Ratio::from_u8(255),
-                a: 255,
-            }
-        );
-        let printed_hsl = format!(
-            "{}",
-            HSL {
-                h: Angle::new(6),
-                s: Ratio::from_percentage(93),
-                l: Ratio::from_percentage(71),
-            }
-        );
-        let printed_hsla = format!(
-            "{}",
-            HSLA {
-                h: Angle::new(6),
-                s: Ratio::from_percentage(93),
-                l: Ratio::from_percentage(71),
-                a: 255,
-            }
-        );
+        let printed_rgb = format!("{}", RGB::new(5, 10, 255));
+        let printed_rgba = format!("{}", RGBA::new(5, 10, 255, 255));
+        let printed_hsl = format!("{}", HSL::new(6, 93, 71));
+        let printed_hsla = format!("{}", HSLA::new(6, 93, 71, 255));
 
         // TODO: You should probably be able to write rgb in both formats (percentage and u8).
         // Need to add the ability to do that, and then these two tests will pass.
@@ -811,28 +650,10 @@ mod css_color_tests {
 
     #[test]
     fn can_be_displayed() {
-        let rgb = RGB {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(255),
-        };
-        let rgba = RGBA {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(255),
-            a: 190,
-        };
-        let hsl = HSL {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-        };
-        let hsla = HSLA {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-            a: 255,
-        };
+        let rgb = RGB::new(5, 10, 255);
+        let rgba = RGBA::new(5, 10, 255, 190);
+        let hsl = HSL::new(6, 93, 71);
+        let hsla = HSLA::new(6, 93, 71, 255);
 
         // TODO: You should probably be able to write rgb in both formats (percentage and u8).
         // Need to add the ability to do that, and then these two tests will pass.
@@ -847,28 +668,10 @@ mod css_color_tests {
 
     #[test]
     fn can_be_stringified() {
-        let rgb = RGB {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(255),
-        };
-        let rgba = RGBA {
-            r: Ratio::from_u8(5),
-            g: Ratio::from_u8(10),
-            b: Ratio::from_u8(255),
-            a: 128,
-        };
-        let hsl = HSL {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-        };
-        let hsla = HSLA {
-            h: Angle::new(6),
-            s: Ratio::from_percentage(93),
-            l: Ratio::from_percentage(71),
-            a: 128,
-        };
+        let rgb = RGB::new(5, 10, 255);
+        let rgba = RGBA::new(5, 10, 255, 128);
+        let hsl = HSL::new(6, 93, 71);
+        let hsla = HSLA::new(6, 93, 71, 128);
 
         // TODO: You should probably be able to write rgb in both formats (percentage and u8).
         // Need to add the ability to do that, and then these two tests will pass.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,10 +146,10 @@ impl Color for RGB {
         if r == g && g == b {
             return HSL::new(
                 Angle::new(0),
-                0,
+                Ratio::from_percentage(0),
                 // TODO Ratio::from_u8(r)
                 // or just `r` (if `r` is a Ratio already)
-                (100.0 * (r as f32) / 255.0).round() as u8,
+                Ratio::from_u8(r)
             );
         }
 
@@ -214,8 +214,8 @@ impl Color for RGB {
 
         HSL::new(
             Angle::new(hue.round() as u16),
-            (100.0 * saturation).round() as u8, // Ratio::from_f32(saturation)
-            (100.0 * luminosity).round() as u8,
+            Ratio::from_f32(saturation), // (100.0 * saturation).round() as u8,
+            Ratio::from_f32(saturation), // (100.0 * luminosity).round() as u8,
         )
     }
 
@@ -311,10 +311,10 @@ pub struct HSL {
     pub h: Angle,
 
     // saturation
-    pub s: u8,
+    pub s: Ratio,
 
     // luminosity
-    pub l: u8,
+    pub l: Ratio,
 }
 
 impl fmt::Display for HSL {
@@ -334,7 +334,7 @@ impl HSL {
     ///
     /// assert_eq!(salmon, HSL { h: Angle::new(6), s: 93, l: 71 });
     /// ```
-    pub fn new(h: Angle, s: u8, l: u8) -> HSL {
+    pub fn new(h: Angle, s: Ratio, l: Ratio) -> HSL {
         HSL { h, s, l }
     }
 }
@@ -377,10 +377,10 @@ pub struct HSLA {
     pub h: Angle,
 
     // saturation
-    pub s: u8,
+    pub s: Ratio,
 
     // luminosity
-    pub l: u8,
+    pub l: Ratio,
 
     // alpha
     pub a: u8,
@@ -409,7 +409,7 @@ impl HSLA {
     ///
     /// assert_eq!(light_salmon, HSLA { h: Angle::new(6), s: 93, l: 71, a: 128 });
     /// ```
-    pub fn new(h: Angle, s: u8, l: u8, a: u8) -> HSLA {
+    pub fn new(h: Angle, s: Ratio, l: Ratio, a: u8) -> HSLA {
         HSLA { h, s, l, a }
     }
 }
@@ -441,7 +441,7 @@ impl Color for HSLA {
 
 #[cfg(test)]
 mod css_color_tests {
-    use {Angle, Color, HSL, HSLA, RGB, RGBA};
+    use {Angle, Ratio, Color, HSL, HSLA, RGB, RGBA};
 
     #[test]
     fn can_create_color_structs() {
@@ -456,19 +456,19 @@ mod css_color_tests {
             }
         );
         assert_eq!(
-            HSL::new(Angle::new(6), 93, 71),
+            HSL::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71)),
             HSL {
                 h: Angle::new(6),
-                s: 93,
-                l: 71
+                s: Ratio::from_percentage(93),
+                l: Ratio::from_percentage(71)
             }
         );
         assert_eq!(
-            HSLA::new(Angle::new(6), 93, 71, 255),
+            HSLA::new(Angle::new(6), Ratio::from_percentage(93), Ratio::from_percentage(71), 255),
             HSLA {
                 h: Angle::new(6),
-                s: 93,
-                l: 71,
+                s: Ratio::from_percentage(93),
+                l: Ratio::from_percentage(71),
                 a: 255
             }
         );
@@ -485,13 +485,13 @@ mod css_color_tests {
         };
         let hsl_color = HSL {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71)
         };
         let hsla_color = HSLA {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
             a: 255,
         };
 
@@ -544,13 +544,14 @@ mod css_color_tests {
         };
         let hsl_rust = HSL {
             h: Angle::new(9),
-            s: 35,
-            l: 50,
+            s: Ratio::from_percentage(35),
+            l: Ratio::from_percentage(50),
         };
+
         let hsla_rust = HSLA {
             h: Angle::new(9),
-            s: 35,
-            l: 50,
+            s: Ratio::from_percentage(35),
+            l: Ratio::from_percentage(50),
             a: 255,
         };
 
@@ -574,13 +575,13 @@ mod css_color_tests {
         };
         let hsl_color = HSL {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
         };
         let hsla_color = HSLA {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
             a: 255,
         };
 
@@ -608,14 +609,14 @@ mod css_color_tests {
         let copied_rgba_color = rgba_color;
         let hsl_color = HSL {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
         };
         let copied_hsl_color = hsl_color;
         let hsla_color = HSLA {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
             a: 255,
         };
         let copied_hsla_color = hsla_color;
@@ -642,16 +643,16 @@ mod css_color_tests {
             "{:?}",
             HSL {
                 h: Angle::new(6),
-                s: 93,
-                l: 71,
+                s: Ratio::from_percentage(93),
+                l: Ratio::from_percentage(71),
             }
         );
         let hsla_value = format!(
             "{:?}",
             HSLA {
                 h: Angle::new(6),
-                s: 93,
-                l: 71,
+                s: Ratio::from_percentage(93),
+                l: Ratio::from_percentage(71),
                 a: 255
             }
         );
@@ -680,13 +681,13 @@ mod css_color_tests {
         };
         let hsl = HSL {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
         };
         let hsla = HSLA {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
             a: 255,
         };
 
@@ -719,16 +720,16 @@ mod css_color_tests {
             "{}",
             HSL {
                 h: Angle::new(6),
-                s: 93,
-                l: 71,
+                s: Ratio::from_percentage(93),
+                l: Ratio::from_percentage(71),
             }
         );
         let printed_hsla = format!(
             "{}",
             HSLA {
                 h: Angle::new(6),
-                s: 93,
-                l: 71,
+                s: Ratio::from_percentage(93),
+                l: Ratio::from_percentage(71),
                 a: 255,
             }
         );
@@ -754,13 +755,13 @@ mod css_color_tests {
         };
         let hsl = HSL {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
         };
         let hsla = HSLA {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
             a: 255,
         };
 
@@ -785,13 +786,13 @@ mod css_color_tests {
         };
         let hsl = HSL {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
         };
         let hsla = HSLA {
             h: Angle::new(6),
-            s: 93,
-            l: 71,
+            s: Ratio::from_percentage(93),
+            l: Ratio::from_percentage(71),
             a: 128,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub trait Color {
 #[derive(Debug, Copy, Clone, PartialEq)]
 /// A struct to represent how much red, green, and blue should be added to create a color.
 ///
-/// Valid values for r, g, and b must fall between `0-255`.
+/// Valid values for r, g, and b must be a u8 between `0-255`, represented as a `Ratio`.
 ///
 /// For more, see the [CSS Color Spec](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#rgb-color).
 pub struct RGB {
@@ -154,8 +154,6 @@ impl Color for RGB {
         // Otherwise, to determine luminosity, we conver the RGB values into a
         // percentage value, find the max and the min of those values, sum them
         // together, and divide by 2.
-
-        // TODO: delete me let r = self.r.to_f32() if r is a Ratio
         let r = Ratio::as_f32(self.r);
         let g = Ratio::as_f32(self.g);
         let b = Ratio::as_f32(self.b);
@@ -227,7 +225,8 @@ impl Color for RGB {
 /// A struct to represent how much red, green, and blue should be added to create a color.
 /// Also handles alpha specifications.
 ///
-/// Valid values for r, g, b, and a must fall between `0-255`.
+/// Valid values for r, g, and b must be a u8 between `0-255`, represented as a `Ratio`.
+/// Alpha (a) values must fall between `0-255`.
 ///
 /// For more, see the [CSS Color Spec](https://www.w3.org/TR/2018/REC-css-color-3-20180619/#rgba-color).
 pub struct RGBA {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 
 pub mod angle;
+pub mod ratio;
 use angle::Angle;
+use ratio::Ratio;
 
 /// A trait that can be used for converting between different color models
 /// and performing various transformations on them.

--- a/src/ratio/mod.rs
+++ b/src/ratio/mod.rs
@@ -39,7 +39,7 @@ impl Ratio {
 
 impl fmt::Display for Ratio {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}%", self.as_percentage())
     }
 }
 
@@ -77,7 +77,7 @@ impl ops::Div for Ratio {
 
 #[cfg(test)]
 mod tests {
-    use {Ratio};
+    use Ratio;
 
     #[test]
     #[should_panic]
@@ -93,9 +93,18 @@ mod tests {
 
     #[test]
     fn handles_overflow_percentage() {
-        assert_eq!(Ratio::from_percentage(50) + Ratio::from_percentage(55), None);
-        assert_eq!(Ratio::from_percentage(50) - Ratio::from_percentage(55), None);
-        assert_eq!(Ratio::from_percentage(50) * Ratio::from_percentage(55), None);
+        assert_eq!(
+            Ratio::from_percentage(50) + Ratio::from_percentage(55),
+            None
+        );
+        assert_eq!(
+            Ratio::from_percentage(50) - Ratio::from_percentage(55),
+            None
+        );
+        assert_eq!(
+            Ratio::from_percentage(50) * Ratio::from_percentage(55),
+            None
+        );
     }
 
     #[test]

--- a/src/ratio/mod.rs
+++ b/src/ratio/mod.rs
@@ -1,0 +1,123 @@
+use std::ops;
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+/// A struct that represents a ratio and determines the legal value(s) for a given type.
+/// Used to convert a type into a valid percentage representation.
+pub struct Ratio(u8);
+
+impl Ratio {
+    pub fn from_percentage(percentage: u8) -> Self {
+        assert!(percentage <= 100, "Invalid value for percentage");
+
+        Ratio((percentage as f32 / 100.0 * 255.0).round() as u8)
+    }
+
+    pub fn from_u8(value: u8) -> Self {
+        Ratio(value)
+    }
+
+    pub fn from_f32(float: f32) -> Self {
+        assert!(float >= 0.0, "Invalid ratio for type f32");
+        assert!(float <= 1.0, "Invalid ratio for type f32");
+
+        Ratio((float / 1.0 * 255.0).round() as u8)
+    }
+
+    pub fn as_percentage(self) -> u8 {
+        (self.0 as f32 / 255.0 * 100.0).round() as u8
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
+
+    pub fn as_f32(self) -> f32 {
+        self.0 as f32 / 255.0
+    }
+}
+
+impl ops::Add for Ratio {
+    type Output = Option<Ratio>;
+
+    fn add(self, other: Ratio) -> Option<Ratio> {
+        self.0.checked_add(other.0).map(|total| Ratio(total))
+    }
+}
+
+impl ops::Sub for Ratio {
+    type Output = Option<Ratio>;
+
+    fn sub(self, other: Ratio) -> Option<Ratio> {
+        self.0.checked_sub(other.0).map(|total| Ratio(total))
+    }
+}
+
+impl ops::Mul for Ratio {
+    type Output = Option<Ratio>;
+
+    fn mul(self, other: Ratio) -> Option<Ratio> {
+        self.0.checked_mul(other.0).map(|total| Ratio(total))
+    }
+}
+
+impl ops::Div for Ratio {
+    type Output = Option<Ratio>;
+
+    fn div(self, other: Ratio) -> Option<Ratio> {
+        self.0.checked_div(other.0).map(|total| Ratio(total))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {Ratio};
+
+    #[test]
+    #[should_panic]
+    fn handles_invalid_percentage() {
+        Ratio::from_percentage(101);
+    }
+
+    #[test]
+    #[should_panic]
+    fn handles_invalid_f32() {
+        Ratio::from_f32(1.01);
+    }
+
+    #[test]
+    fn handles_overflow_percentage() {
+        assert_eq!(Ratio::from_percentage(50) + Ratio::from_percentage(55), None);
+        assert_eq!(Ratio::from_percentage(50) - Ratio::from_percentage(55), None);
+        assert_eq!(Ratio::from_percentage(50) * Ratio::from_percentage(55), None);
+    }
+
+    #[test]
+    fn handles_overflow_f32() {
+        assert_eq!(Ratio::from_f32(0.75) + Ratio::from_f32(0.75), None);
+        assert_eq!(Ratio::from_f32(0.25) - Ratio::from_f32(0.75), None);
+        assert_eq!(Ratio::from_f32(0.07) * Ratio::from_f32(0.06), None);
+    }
+
+    #[test]
+    fn computes_valid_percentage() {
+        let a = Ratio::from_percentage(55);
+        let b = Ratio::from_percentage(45);
+        let c = Ratio::from_percentage(10);
+        // let d = Ratio::from_percentage(5);
+
+        assert_eq!((a + b).unwrap(), Ratio::from_percentage(100));
+        assert_eq!((b - c).unwrap(), Ratio::from_percentage(35));
+        // FIXME: need to figure out why this dosen't work as expected.
+        // assert_eq!((a / d).unwrap(), Ratio::from_percentage(11));
+    }
+
+    #[test]
+    fn computes_valid_f32() {
+        let a = Ratio::from_f32(0.55);
+        let b = Ratio::from_f32(0.45);
+        let c = Ratio::from_f32(0.10);
+
+        assert_eq!((a + b).unwrap(), Ratio::from_f32(1.0));
+        assert_eq!((b - c).unwrap(), Ratio::from_f32(0.35));
+    }
+}

--- a/src/ratio/mod.rs
+++ b/src/ratio/mod.rs
@@ -10,7 +10,7 @@ impl Ratio {
     pub fn from_percentage(percentage: u8) -> Self {
         assert!(percentage <= 100, "Invalid value for percentage");
 
-        Ratio((percentage as f32 / 100.0 * 255.0).round() as u8)
+        Ratio::from_f32(percentage as f32 / 100.0)
     }
 
     pub fn from_u8(value: u8) -> Self {
@@ -21,7 +21,7 @@ impl Ratio {
         assert!(float >= 0.0, "Invalid ratio for type f32");
         assert!(float <= 1.0, "Invalid ratio for type f32");
 
-        Ratio((float / 1.0 * 255.0).round() as u8)
+        Ratio((float * 255.0).round() as u8)
     }
 
     pub fn as_percentage(self) -> u8 {
@@ -115,22 +115,87 @@ mod tests {
     }
 
     #[test]
-    fn computes_valid_percentage() {
+    fn adds_percentage() {
         let a = Ratio::from_percentage(55);
         let b = Ratio::from_percentage(45);
         let c = Ratio::from_percentage(10);
 
         assert_eq!((a + b).unwrap(), Ratio::from_percentage(100));
-        assert_eq!((b - c).unwrap(), Ratio::from_percentage(35));
+        assert_eq!((a + c).unwrap(), Ratio::from_percentage(65));
     }
 
     #[test]
-    fn computes_valid_f32() {
+    fn subtracts_percentage() {
+        let a = Ratio::from_percentage(45);
+        let b = Ratio::from_percentage(10);
+        let c = Ratio::from_percentage(1);
+
+        assert_eq!((a - b).unwrap(), Ratio::from_percentage(35));
+        assert_eq!((b - c).unwrap(), Ratio::from_percentage(9));
+    }
+
+    #[test]
+    fn multiplies_percentage() {
+        let a = Ratio::from_percentage(10);
+        let b = Ratio::from_percentage(1);
+        let c = Ratio::from_percentage(2);
+
+        assert_eq!((b * c).unwrap(), Ratio::from_u8(15));
+        assert_eq!((c * c).unwrap(), Ratio::from_u8(25));
+        assert_eq!((a * b).unwrap(), Ratio::from_u8(78));
+    }
+
+    #[test]
+    fn divides_percentage() {
+        let a = Ratio::from_percentage(45);
+        let b = Ratio::from_percentage(10);
+        let c = Ratio::from_percentage(1);
+
+        assert_eq!((b / c).unwrap(), Ratio::from_u8(8));
+        assert_eq!((a / c).unwrap(), Ratio::from_u8(38));
+        assert_eq!((a / b).unwrap(), Ratio::from_u8(4));
+    }
+
+    #[test]
+    fn adds_f32() {
         let a = Ratio::from_f32(0.55);
         let b = Ratio::from_f32(0.45);
         let c = Ratio::from_f32(0.10);
 
         assert_eq!((a + b).unwrap(), Ratio::from_f32(1.0));
+        assert_eq!((c + c).unwrap(), Ratio::from_u8(52));
+        // This seems to be lossy; possible to test like this?
+        // assert_eq!((c + c).unwrap(), Ratio::from_f32(0.2));
+    }
+
+    #[test]
+    fn subtracts_f32() {
+        let a = Ratio::from_f32(0.55);
+        let b = Ratio::from_f32(0.45);
+        let c = Ratio::from_f32(0.10);
+
         assert_eq!((b - c).unwrap(), Ratio::from_f32(0.35));
+        assert_eq!((a - b).unwrap(), Ratio::from_u8(25));
+        // assert_eq!((a - b).unwrap(), Ratio::from_f32(0.10));
+    }
+
+    #[test]
+    fn multiplies_f32() {
+        let a = Ratio::from_f32(0.01);
+        let b = Ratio::from_f32(0.02);
+
+        assert_eq!((a * b).unwrap(), Ratio::from_u8(15));
+        assert_eq!((a * a).unwrap(), Ratio::from_u8(9));
+        // assert_eq!((a * a).unwrap(), Ratio::from_f32(0.0001));
+    }
+
+    #[test]
+    fn divides_f32() {
+        let a = Ratio::from_f32(0.25);
+        let b = Ratio::from_f32(0.50);
+        let c = Ratio::from_f32(0.75);
+
+        assert_eq!((b / a).unwrap(), Ratio::from_u8(2));
+        assert_eq!((c / b).unwrap(), Ratio::from_u8(1));
     }
 }

--- a/src/ratio/mod.rs
+++ b/src/ratio/mod.rs
@@ -119,12 +119,9 @@ mod tests {
         let a = Ratio::from_percentage(55);
         let b = Ratio::from_percentage(45);
         let c = Ratio::from_percentage(10);
-        // let d = Ratio::from_percentage(5);
 
         assert_eq!((a + b).unwrap(), Ratio::from_percentage(100));
         assert_eq!((b - c).unwrap(), Ratio::from_percentage(35));
-        // FIXME: need to figure out why this dosen't work as expected.
-        // assert_eq!((a / d).unwrap(), Ratio::from_percentage(11));
     }
 
     #[test]

--- a/src/ratio/mod.rs
+++ b/src/ratio/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::ops;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
@@ -33,6 +34,12 @@ impl Ratio {
 
     pub fn as_f32(self) -> f32 {
         self.0 as f32 / 255.0
+    }
+}
+
+impl fmt::Display for Ratio {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
- [x] Adds a `Ratio` module
- [x] Impls `Ratio` to be used in `HSL` & `HSLA`
- [x] Impls `Ratio` to be used in `RGB`, `RGBA`. This causes RGB/A to be rendered in css as _percentages_ for now (which is valid css, but kind of limiting). I will need to change the impl for RGB/A so that they can also render css with the color values in `u8`.