### PR TITLE
Fix broken license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ We run our test suite against the Rust stable, beta, and nightly versions on Tra
 
 ## License
 
-This project is licensed under the [ISC License](LICENSE.md).
+This project is licensed under the [ISC License](LICENSE).


### PR DESCRIPTION
The existing link points to an outdated file.

Thanks for the cool library!